### PR TITLE
Feature/twist reference frame fix

### DIFF
--- a/mru_transform/config/ixblue_ins.yaml
+++ b/mru_transform/config/ixblue_ins.yaml
@@ -10,9 +10,9 @@
     sensors:
       ixblue_ins:
         topics:
-          orientation: /ixblue_ins_driver/standard/imu
-          position: /ixblue_ins_driver/standard/navsatfix
-          velocity: ""
+          orientation: "/ixblue_ins_driver/standard/imu"
+          position: "/ixblue_ins_driver/standard/navsatfix"
+          velocity: "/ixblue_ins_driver/standard/twist"
     sensors_names:
     - ixblue_ins
     use_sim_time: false

--- a/mru_transform/include/mru_transform/sensor.hpp
+++ b/mru_transform/include/mru_transform/sensor.hpp
@@ -63,15 +63,25 @@ protected:
       subscribeCheck();
   }
 
+  std::string resolve_topic_name(const std::string& topic_name) {
+    std::string namespace_ = node_ptr_->get_namespace();
+    if (!namespace_.empty() && namespace_.front() != '/') {
+      namespace_ = "/" + namespace_;
+    }
+    return namespace_ + "/" + topic_name;
+  }
   void subscribeCheck()
   {
     //auto topic_type = getROSType(nh.resolveName(topic_));
     //auto topic_types = node_ptr_->get_topic_names_and_types()[topic_];
-    auto topic_type = node_ptr_->get_topic_names_and_types()[topic_];
+
+    auto topic = resolve_topic_name(topic_);
+
+    auto topic_type = node_ptr_->get_topic_names_and_types()[topic];
 
     if(topic_type.empty()){
       std::stringstream msg;
-      msg << "Unknown " << T::sensor_type << " topic type for: " << topic_;
+      msg << "Unknown " << T::sensor_type << " topic type for: " << topic;
 
       RCLCPP_WARN_THROTTLE(
           node_ptr_->get_logger(),

--- a/mru_transform/package.xml
+++ b/mru_transform/package.xml
@@ -12,13 +12,13 @@
 
 
   <depend>project11</depend>
-  <depend>roscpp</depend>
+  <depend>rclcpp</depend>
   <depend>tf2</depend>
   <depend>tf2_ros</depend>
   <depend>sensor_msgs</depend>
   <depend>marine_acoustic_msgs</depend>
   <depend>nav_msgs</depend>
-  <depend>message_generation</depend>
+<!--  <depend>message_generation</depend>-->
   <depend>mru_transform_interfaces</depend>
 
   <!-- The export tag contains other, unspecified, tags -->

--- a/mru_transform/src/mru_transform.cpp
+++ b/mru_transform/src/mru_transform.cpp
@@ -148,9 +148,10 @@ void MRUTransform::updateVelocity(const rclcpp::Time &now)
     tf2::Quaternion orientation_quat;
     tf2::fromMsg(latest_orientation_.orientation, orientation_quat);
 
-    geometry_msgs::msg::TransformStamped odom_base_rotation;
-    odom_base_rotation.transform.rotation = tf2::toMsg(orientation_quat.inverse());
-    tf2::doTransform(latest_velocity_.twist.linear, odom_.twist.twist.linear, odom_base_rotation);
+    //geometry_msgs::msg::TransformStamped odom_base_rotation;
+    // odom_base_rotation.transform.rotation = tf2::toMsg(orientation_quat.inverse());
+    // tf2::doTransform(latest_velocity_.twist.linear, odom_.twist.twist.linear, odom_base_rotation);
+    odom_.twist.twist.linear = latest_velocity_.twist.linear;
     odom_pub_->publish(odom_);
   }
 }

--- a/mru_transform_interfaces/CMakeLists.txt
+++ b/mru_transform_interfaces/CMakeLists.txt
@@ -8,7 +8,6 @@ find_package(ament_cmake REQUIRED)
 find_package(rosidl_default_generators REQUIRED)
 
 find_package(geographic_msgs REQUIRED)
-find_package(marine_acoustic_msgs REQUIRED)
 find_package(std_msgs REQUIRED)
 
 set(MSG_FILES


### PR DESCRIPTION
Modified the reference frame of the twist component of the odom message.   Initially the twist component represented velocity in the `header.frame_id` frame.   It should be represented in the `child_frame` according to the [message definition](https://docs.ros.org/en/noetic/api/nav_msgs/html/msg/Odometry.html)