### PR TITLE
Fix rosdep key: libproj-dev → proj

### DIFF
--- a/mru_transform/package.xml
+++ b/mru_transform/package.xml
@@ -23,7 +23,7 @@
   <depend>tf2_msgs</depend>
   <depend>tf2_ros</depend>
 
-  <depend>libproj-dev</depend>
+  <depend>proj</depend>
   <exec_depend>proj-data</exec_depend>
 
   <!-- The export tag contains other, unspecified, tags -->


### PR DESCRIPTION
## Summary

- Change `libproj-dev` (apt package name) to `proj` (rosdep key) in `mru_transform/package.xml`

Closes #11

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.6`
