### PR TITLE
Remove redundant proj-data dependency

### DIFF
--- a/mru_transform/package.xml
+++ b/mru_transform/package.xml
@@ -24,7 +24,6 @@
   <depend>tf2_ros</depend>
 
   <depend>proj</depend>
-  <exec_depend>proj-data</exec_depend>
 
   <!-- The export tag contains other, unspecified, tags -->
   <export>


### PR DESCRIPTION
## Summary

- Remove redundant `<exec_depend>proj-data</exec_depend>` — already pulled in transitively via `proj`

Closes #13

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.6`
