### PR TITLE
feat: publish MHHW datum frame and reject out-of-range tide estimates

### DIFF
--- a/mru_transform/CMakeLists.txt
+++ b/mru_transform/CMakeLists.txt
@@ -17,6 +17,7 @@ find_package(nav_msgs REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(rclcpp_lifecycle REQUIRED)
 find_package(sensor_msgs REQUIRED)
+find_package(std_msgs REQUIRED)
 find_package(std_srvs REQUIRED)
 find_package(tf2 REQUIRED)
 find_package(tf2_geometry_msgs REQUIRED)
@@ -156,6 +157,7 @@ target_link_libraries(chart_datum_node
   rclcpp::rclcpp
   rclcpp_lifecycle::rclcpp_lifecycle
   ${geometry_msgs_TARGETS}
+  ${std_msgs_TARGETS}
   tf2::tf2
   tf2_ros::tf2_ros
   PkgConfig::PROJ
@@ -232,10 +234,11 @@ if(MLLW_COUNT EQUAL 0)
   endif()
 
   if(EXISTS "${VDATUM_ZIP_CACHE}")
-    message(STATUS "Extracting MLLW grids from VDatum archive...")
+    message(STATUS "Extracting MLLW and MHHW grids from VDatum archive...")
     file(MAKE_DIRECTORY "${VDATUM_EXTRACT_DIR}")
     execute_process(
-      COMMAND unzip -o "${VDATUM_ZIP_CACHE}" "*_mllw.gtx" "*.bnd" "*.met"
+      COMMAND unzip -o "${VDATUM_ZIP_CACHE}"
+        "*_mllw.gtx" "*_mhhw.gtx" "*.bnd" "*.met"
       WORKING_DIRECTORY "${VDATUM_EXTRACT_DIR}"
       RESULT_VARIABLE UNZIP_RESULT
     )
@@ -245,6 +248,20 @@ if(MLLW_COUNT EQUAL 0)
   endif()
 else()
   message(STATUS "VDatum MLLW grids cached: ${MLLW_COUNT} files")
+  # Extract MHHW grids if missing (upgrade from older cache)
+  file(GLOB MHHW_GRIDS_CHECK "${VDATUM_EXTRACT_DIR}/vdatum/*/*_mhhw.gtx")
+  list(LENGTH MHHW_GRIDS_CHECK MHHW_CHECK_COUNT)
+  if(MHHW_CHECK_COUNT EQUAL 0 AND EXISTS "${VDATUM_ZIP_CACHE}")
+    message(STATUS "Extracting MHHW grids from cached VDatum archive...")
+    execute_process(
+      COMMAND unzip -o "${VDATUM_ZIP_CACHE}" "*_mhhw.gtx"
+      WORKING_DIRECTORY "${VDATUM_EXTRACT_DIR}"
+      RESULT_VARIABLE UNZIP_MHHW_RESULT
+    )
+    if(NOT UNZIP_MHHW_RESULT EQUAL 0)
+      message(WARNING "Failed to extract MHHW grids (non-fatal)")
+    endif()
+  endif()
 endif()
 
 # Install grids to package share directory
@@ -255,9 +272,10 @@ if(EXISTS "${GEOID_CACHE}")
 endif()
 
 file(GLOB MLLW_GRIDS "${VDATUM_EXTRACT_DIR}/vdatum/*/*_mllw.gtx")
+file(GLOB MHHW_GRIDS "${VDATUM_EXTRACT_DIR}/vdatum/*/*_mhhw.gtx")
 file(GLOB VDATUM_BND "${VDATUM_EXTRACT_DIR}/vdatum/*/*.bnd")
 file(GLOB VDATUM_MET "${VDATUM_EXTRACT_DIR}/vdatum/*/*.met")
-foreach(GRID_FILE ${MLLW_GRIDS} ${VDATUM_BND} ${VDATUM_MET})
+foreach(GRID_FILE ${MLLW_GRIDS} ${MHHW_GRIDS} ${VDATUM_BND} ${VDATUM_MET})
   # Preserve the regional subdirectory structure
   file(RELATIVE_PATH REL_PATH "${VDATUM_EXTRACT_DIR}" "${GRID_FILE}")
   get_filename_component(REL_DIR "${REL_PATH}" DIRECTORY)

--- a/mru_transform/CMakeLists.txt
+++ b/mru_transform/CMakeLists.txt
@@ -120,6 +120,7 @@ target_link_libraries(sea_surface_estimator
   rclcpp::rclcpp
   rclcpp_lifecycle::rclcpp_lifecycle
   ${nav_msgs_TARGETS}
+  ${std_msgs_TARGETS}
   tf2_ros::tf2_ros
 )
 

--- a/mru_transform/nodes/chart_datum_node.cpp
+++ b/mru_transform/nodes/chart_datum_node.cpp
@@ -92,8 +92,9 @@ public:
     tf_broadcaster_ =
       std::make_shared<tf2_ros::TransformBroadcaster>(*this);
 
-    mllw_pub_ = create_publisher<std_msgs::msg::Float64>("mllw_offset", 10);
-    mhhw_pub_ = create_publisher<std_msgs::msg::Float64>("mhhw_offset", 10);
+    auto latched_qos = rclcpp::QoS(1).transient_local();
+    mllw_pub_ = create_publisher<std_msgs::msg::Float64>("mllw_offset", latched_qos);
+    mhhw_pub_ = create_publisher<std_msgs::msg::Float64>("mhhw_offset", latched_qos);
 
     return LifecycleNode::on_configure(state);
   }

--- a/mru_transform/nodes/chart_datum_node.cpp
+++ b/mru_transform/nodes/chart_datum_node.cpp
@@ -1,10 +1,10 @@
-// chart_datum_node.cpp — Publishes the map → chart_datum TF transform
+// chart_datum_node.cpp — Publishes map → chart_datum TF transforms
 //
 // Uses PROJ to compute the static vertical offset between the WGS84
-// ellipsoid (map frame) and chart datum (MLLW) at the robot's current
-// position. The offset is position-dependent and recalculated
-// periodically. The transform is published at a faster rate using
-// the cached value.
+// ellipsoid (map frame) and tidal datums (MLLW, MHHW) at the robot's
+// current position. The offsets are position-dependent and recalculated
+// periodically. Transforms are published at a faster rate using
+// cached values.
 //
 // Position is obtained from the TF tree (earth → base_link → ECEF →
 // lat/lon via geodesy).
@@ -12,6 +12,7 @@
 // Requires:
 //   - PROJ geoid grid (e.g., us_noaa_g2018u0.tif) for ellipsoid → NAVD88
 //   - VDatum regional .gtx grids for NAVD88 → MLLW
+//   - VDatum regional .gtx grids for NAVD88 → MHHW (optional)
 
 #include <cmath>
 #include <filesystem>
@@ -23,6 +24,7 @@
 #include "rclcpp/rclcpp.hpp"
 #include "rclcpp_lifecycle/lifecycle_node.hpp"
 #include "lifecycle_msgs/msg/state.hpp"
+#include "std_msgs/msg/float64.hpp"
 #include "tf2_ros/buffer.h"
 #include "tf2_ros/transform_broadcaster.h"
 #include "tf2_ros/transform_listener.h"
@@ -49,6 +51,9 @@ public:
   {
     declare_parameter("chart_datum_frame", chart_datum_frame_);
     get_parameter("chart_datum_frame", chart_datum_frame_);
+
+    declare_parameter("mhhw_frame", mhhw_frame_);
+    get_parameter("mhhw_frame", mhhw_frame_);
 
     declare_parameter("map_frame", map_frame_);
     get_parameter("map_frame", map_frame_);
@@ -87,6 +92,9 @@ public:
     tf_broadcaster_ =
       std::make_shared<tf2_ros::TransformBroadcaster>(*this);
 
+    mllw_pub_ = create_publisher<std_msgs::msg::Float64>("mllw_offset", 10);
+    mhhw_pub_ = create_publisher<std_msgs::msg::Float64>("mhhw_offset", 10);
+
     return LifecycleNode::on_configure(state);
   }
 
@@ -123,23 +131,51 @@ public:
   }
 
 private:
+  // Collect .gtx grid files matching a suffix (e.g., "_mllw")
+  std::string collect_grids(const std::string & suffix)
+  {
+    std::string grids;
+    for (const auto & entry :
+      fs::recursive_directory_iterator(vdatum_grid_dir_))
+    {
+      if (entry.path().extension() == ".gtx" &&
+        entry.path().stem().string().find(suffix) !=
+        std::string::npos)
+      {
+        if (!grids.empty()) {
+          grids += ",";
+        }
+        grids += entry.path().string();
+      }
+    }
+    return grids;
+  }
+
+  // Create a PROJ pipeline: ellipsoid → NAVD88 → target datum
+  PJ * create_pipeline(const std::string & datum_grids)
+  {
+    std::string pipeline =
+      "+proj=pipeline "
+      "+step +proj=vgridshift +grids=" + geoid_grid_path_ + " "
+      "+step +proj=vgridshift +grids=" + datum_grids;
+
+    PJ * pj = proj_create(proj_context_, pipeline.c_str());
+    if (!pj) {
+      RCLCPP_ERROR(
+        get_logger(), "Failed to create PROJ pipeline: %s",
+        proj_context_errno_string(
+          proj_context_, proj_context_errno(proj_context_)));
+    }
+    return pj;
+  }
+
   bool setup_proj()
   {
     std::string mllw_grids;
+    std::string mhhw_grids;
     try {
-      for (const auto & entry :
-        fs::recursive_directory_iterator(vdatum_grid_dir_))
-      {
-        if (entry.path().extension() == ".gtx" &&
-          entry.path().stem().string().find("_mllw") !=
-          std::string::npos)
-        {
-          if (!mllw_grids.empty()) {
-            mllw_grids += ",";
-          }
-          mllw_grids += entry.path().string();
-        }
-      }
+      mllw_grids = collect_grids("_mllw");
+      mhhw_grids = collect_grids("_mhhw");
     } catch (const fs::filesystem_error & e) {
       RCLCPP_ERROR(
         get_logger(), "Error scanning vdatum_grid_dir '%s': %s",
@@ -154,43 +190,68 @@ private:
       return false;
     }
 
-    RCLCPP_INFO(
-      get_logger(), "Found MLLW grids in %s",
+    RCLCPP_INFO(get_logger(), "Found MLLW grids in %s",
       vdatum_grid_dir_.c_str());
-
-    std::string pipeline =
-      "+proj=pipeline "
-      "+step +proj=vgridshift +grids=" + geoid_grid_path_ + " "
-      "+step +proj=vgridshift +grids=" + mllw_grids;
 
     proj_context_ = proj_context_create();
     proj_context_set_enable_network(proj_context_, false);
 
-    proj_ = proj_create(proj_context_, pipeline.c_str());
-    if (!proj_) {
-      RCLCPP_ERROR(
-        get_logger(), "Failed to create PROJ pipeline: %s",
-        proj_context_errno_string(
-          proj_context_, proj_context_errno(proj_context_)));
+    proj_mllw_ = create_pipeline(mllw_grids);
+    if (!proj_mllw_) {
       proj_context_destroy(proj_context_);
       proj_context_ = nullptr;
       return false;
     }
 
-    RCLCPP_INFO(get_logger(), "PROJ pipeline ready");
+    RCLCPP_INFO(get_logger(), "PROJ MLLW pipeline ready");
+
+    if (!mhhw_grids.empty()) {
+      proj_mhhw_ = create_pipeline(mhhw_grids);
+      if (proj_mhhw_) {
+        RCLCPP_INFO(get_logger(), "PROJ MHHW pipeline ready");
+      } else {
+        RCLCPP_WARN(get_logger(),
+          "Failed to create MHHW pipeline — MHHW frame will not be published");
+      }
+    } else {
+      RCLCPP_WARN(get_logger(),
+        "No *_mhhw.gtx files found — MHHW frame will not be published");
+    }
+
     return true;
   }
 
   void cleanup_proj()
   {
-    if (proj_) {
-      proj_destroy(proj_);
-      proj_ = nullptr;
+    if (proj_mllw_) {
+      proj_destroy(proj_mllw_);
+      proj_mllw_ = nullptr;
+    }
+    if (proj_mhhw_) {
+      proj_destroy(proj_mhhw_);
+      proj_mhhw_ = nullptr;
     }
     if (proj_context_) {
       proj_context_destroy(proj_context_);
       proj_context_ = nullptr;
     }
+  }
+
+  // Query a PROJ pipeline and return the negated Z (datum below ellipsoid)
+  bool query_datum(PJ * pipeline, double lon_rad, double lat_rad,
+    double & result_z)
+  {
+    PJ_COORD input = proj_coord(lon_rad, lat_rad, 0.0, 0.0);
+    PJ_COORD output = proj_trans(pipeline, PJ_FWD, input);
+
+    if (output.xyz.z == HUGE_VAL ||
+      std::isinf(output.xyz.z) || std::isnan(output.xyz.z))
+    {
+      return false;
+    }
+
+    result_z = -output.xyz.z;
+    return true;
   }
 
   void recalc_callback()
@@ -215,45 +276,82 @@ private:
 
     auto geo = geodesy::toMsg(geodesy::ECEFPoint(ecef_point));
 
-    // Query PROJ: (lon, lat, 0) → (lon, lat, height_above_mllw)
-    // PROJ C API expects radians for pipeline input
-    PJ_COORD input = proj_coord(
-      proj_torad(geo.longitude), proj_torad(geo.latitude), 0.0, 0.0);
-    PJ_COORD output = proj_trans(proj_, PJ_FWD, input);
+    double lon_rad = proj_torad(geo.longitude);
+    double lat_rad = proj_torad(geo.latitude);
 
-    if (output.xyz.z == HUGE_VAL ||
-      std::isinf(output.xyz.z) || std::isnan(output.xyz.z))
-    {
+    // MLLW (required)
+    double mllw_z;
+    if (!query_datum(proj_mllw_, lon_rad, lat_rad, mllw_z)) {
       RCLCPP_WARN_THROTTLE(
         get_logger(), *get_clock(), 30000,
-        "No VDatum coverage at (%.4f, %.4f)",
+        "No VDatum MLLW coverage at (%.4f, %.4f)",
         geo.latitude, geo.longitude);
       return;
     }
 
-    chart_datum_z_ = -output.xyz.z;
-    has_valid_offset_ = true;
+    chart_datum_z_ = mllw_z;
+    has_valid_mllw_ = true;
 
     RCLCPP_INFO_ONCE(
       get_logger(),
       "Chart datum at (%.4f, %.4f): %.3f m (MLLW below ellipsoid)",
       geo.latitude, geo.longitude, chart_datum_z_);
+
+    // MHHW (optional)
+    if (proj_mhhw_) {
+      double mhhw_z;
+      if (query_datum(proj_mhhw_, lon_rad, lat_rad, mhhw_z)) {
+        mhhw_z_ = mhhw_z;
+        has_valid_mhhw_ = true;
+
+        RCLCPP_INFO_ONCE(
+          get_logger(),
+          "MHHW at (%.4f, %.4f): %.3f m (below ellipsoid), "
+          "tidal range: %.3f m",
+          geo.latitude, geo.longitude, mhhw_z_,
+          mhhw_z_ - chart_datum_z_);
+      } else {
+        RCLCPP_WARN_THROTTLE(
+          get_logger(), *get_clock(), 30000,
+          "No VDatum MHHW coverage at (%.4f, %.4f)",
+          geo.latitude, geo.longitude);
+      }
+    }
   }
 
   void publish_callback()
   {
-    if (!has_valid_offset_) {
-      return;
+    auto stamp = now();
+
+    if (has_valid_mllw_) {
+      geometry_msgs::msg::TransformStamped transform;
+      transform.header.stamp = stamp;
+      transform.header.frame_id = map_frame_;
+      transform.child_frame_id = chart_datum_frame_;
+      transform.transform.translation.z = chart_datum_z_;
+      transform.transform.rotation.w = 1.0;
+
+      tf_broadcaster_->sendTransform(transform);
+
+      std_msgs::msg::Float64 msg;
+      msg.data = chart_datum_z_;
+      mllw_pub_->publish(msg);
     }
 
-    geometry_msgs::msg::TransformStamped transform;
-    transform.header.stamp = now();
-    transform.header.frame_id = map_frame_;
-    transform.child_frame_id = chart_datum_frame_;
-    transform.transform.translation.z = chart_datum_z_;
-    transform.transform.rotation.w = 1.0;
+    if (has_valid_mhhw_) {
+      geometry_msgs::msg::TransformStamped transform;
+      transform.header.stamp = stamp;
+      transform.header.frame_id = map_frame_;
+      transform.child_frame_id = mhhw_frame_;
+      transform.transform.translation.z = mhhw_z_;
+      transform.transform.rotation.w = 1.0;
 
-    tf_broadcaster_->sendTransform(transform);
+      tf_broadcaster_->sendTransform(transform);
+
+      std_msgs::msg::Float64 msg;
+      msg.data = mhhw_z_;
+      mhhw_pub_->publish(msg);
+    }
   }
 
   // TF
@@ -261,16 +359,22 @@ private:
   std::shared_ptr<tf2_ros::TransformListener> tf_listener_;
   std::shared_ptr<tf2_ros::TransformBroadcaster> tf_broadcaster_;
 
+  // Debug publishers
+  rclcpp_lifecycle::LifecyclePublisher<std_msgs::msg::Float64>::SharedPtr mllw_pub_;
+  rclcpp_lifecycle::LifecyclePublisher<std_msgs::msg::Float64>::SharedPtr mhhw_pub_;
+
   // Timers
   rclcpp::TimerBase::SharedPtr publish_timer_;
   rclcpp::TimerBase::SharedPtr recalc_timer_;
 
   // PROJ state
   PJ_CONTEXT * proj_context_ = nullptr;
-  PJ * proj_ = nullptr;
+  PJ * proj_mllw_ = nullptr;
+  PJ * proj_mhhw_ = nullptr;
 
   // Parameters
   std::string chart_datum_frame_ = "chart_datum";
+  std::string mhhw_frame_ = "chart_datum_mhhw";
   std::string map_frame_ = "map";
   std::string base_frame_ = "base_link";
   std::string geoid_grid_path_;
@@ -280,7 +384,9 @@ private:
 
   // Cached state
   double chart_datum_z_ = 0.0;
-  bool has_valid_offset_ = false;
+  double mhhw_z_ = 0.0;
+  bool has_valid_mllw_ = false;
+  bool has_valid_mhhw_ = false;
 };
 
 int main(int argc, char * argv[])

--- a/mru_transform/nodes/sea_surface_estimator.cpp
+++ b/mru_transform/nodes/sea_surface_estimator.cpp
@@ -98,6 +98,11 @@ public:
     }
     double average = sum / odometry_buffer_.size();
 
+    // Always publish raw estimate for debugging, even if rejected below.
+    std_msgs::msg::Float64 tide_msg;
+    tide_msg.data = average;
+    tide_estimate_pub_->publish(tide_msg);
+
     // Check if the estimated tide is within a plausible range using
     // the chart datum (MLLW) and MHHW frames published by chart_datum_node.
     if (!chart_datum_frame_.empty() && !mhhw_frame_.empty()) {
@@ -113,10 +118,6 @@ public:
     transform.transform.rotation.w = 1.0;
 
     transform_broadcaster_->sendTransform(transform);
-
-    std_msgs::msg::Float64 tide_msg;
-    tide_msg.data = average;
-    tide_estimate_pub_->publish(tide_msg);
   }
 
 private:

--- a/mru_transform/nodes/sea_surface_estimator.cpp
+++ b/mru_transform/nodes/sea_surface_estimator.cpp
@@ -1,9 +1,13 @@
 
+#include <cmath>
+
 #include "rclcpp/rclcpp.hpp"
 #include "rclcpp_lifecycle/lifecycle_node.hpp"
 #include "lifecycle_msgs/msg/state.hpp"
 #include "nav_msgs/msg/odometry.hpp"
+#include "tf2_ros/buffer.h"
 #include "tf2_ros/transform_broadcaster.h"
+#include "tf2_ros/transform_listener.h"
 
 class SeaSurfaceEstimator : public rclcpp_lifecycle::LifecycleNode
 {
@@ -26,7 +30,19 @@ public:
     declare_parameter("maximum_buffer_duration", maximum_buffer_duration_);
     get_parameter("maximum_buffer_duration", maximum_buffer_duration_);
 
+    declare_parameter("chart_datum_frame", chart_datum_frame_);
+    get_parameter("chart_datum_frame", chart_datum_frame_);
+
+    declare_parameter("mhhw_frame", mhhw_frame_);
+    get_parameter("mhhw_frame", mhhw_frame_);
+
+    declare_parameter("tide_range_margin", tide_range_margin_);
+    get_parameter("tide_range_margin", tide_range_margin_);
+
     transform_broadcaster_ = std::make_shared<tf2_ros::TransformBroadcaster>(*this);
+
+    tf_buffer_ = std::make_shared<tf2_ros::Buffer>(get_clock());
+    tf_listener_ = std::make_shared<tf2_ros::TransformListener>(*tf_buffer_);
 
     odometry_subscription_ = create_subscription<nav_msgs::msg::Odometry>(
       "odom", 10, std::bind(&SeaSurfaceEstimator::odometry_callback, this, std::placeholders::_1));
@@ -36,11 +52,13 @@ public:
 
   CallbackReturn  on_activate(const rclcpp_lifecycle::State & state)
   {
-    return LifecycleNode::on_activate(state); 
+    return LifecycleNode::on_activate(state);
   }
 
   CallbackReturn on_cleanup(const rclcpp_lifecycle::State &state)
   {
+    tf_buffer_.reset();
+    tf_listener_.reset();
     return LifecycleNode::on_cleanup(state);
   }
 
@@ -75,6 +93,14 @@ public:
     }
     double average = sum / odometry_buffer_.size();
 
+    // Check if the estimated tide is within a plausible range using
+    // the chart datum (MLLW) and MHHW frames published by chart_datum_node.
+    if (!chart_datum_frame_.empty() && !mhhw_frame_.empty()) {
+      if (is_out_of_range(average, msg->header.frame_id)) {
+        return;
+      }
+    }
+
     geometry_msgs::msg::TransformStamped transform;
     transform.header = msg->header;
     transform.child_frame_id = sea_surface_frame_;
@@ -85,6 +111,43 @@ public:
   }
 
 private:
+  // Check if the estimated sea surface Z is outside the plausible
+  // tidal range. Returns true if the estimate should be rejected.
+  bool is_out_of_range(double estimated_z, const std::string & frame_id)
+  {
+    geometry_msgs::msg::TransformStamped mllw_tf, mhhw_tf;
+    try {
+      mllw_tf = tf_buffer_->lookupTransform(
+        frame_id, chart_datum_frame_, tf2::TimePointZero);
+      mhhw_tf = tf_buffer_->lookupTransform(
+        frame_id, mhhw_frame_, tf2::TimePointZero);
+    } catch (const tf2::TransformException &) {
+      // If datum frames aren't available, don't filter
+      return false;
+    }
+
+    double mllw_z = mllw_tf.transform.translation.z;
+    double mhhw_z = mhhw_tf.transform.translation.z;
+
+    // Tidal range with configurable margin (e.g., 2.0x for storm surge)
+    double tidal_range = std::abs(mhhw_z - mllw_z);
+    double margin = tidal_range * tide_range_margin_;
+    double lower_bound = mllw_z - margin;
+    double upper_bound = mhhw_z + margin;
+
+    if (estimated_z < lower_bound || estimated_z > upper_bound) {
+      RCLCPP_WARN_THROTTLE(
+        get_logger(), *get_clock(), 10000,
+        "Tide estimate %.2f m is outside plausible range "
+        "[%.2f, %.2f] (MLLW=%.2f, MHHW=%.2f, margin=%.1fx) — suppressing",
+        estimated_z, lower_bound, upper_bound,
+        mllw_z, mhhw_z, tide_range_margin_);
+      return true;
+    }
+
+    return false;
+  }
+
   rclcpp::Subscription<nav_msgs::msg::Odometry>::SharedPtr odometry_subscription_;
 
   std::map<rclcpp::Time, nav_msgs::msg::Odometry::SharedPtr> odometry_buffer_;
@@ -96,8 +159,16 @@ private:
   // Maximum duration in seconds to keep in the buffer.
   double maximum_buffer_duration_ = 30.0;
 
-
   std::string sea_surface_frame_ = "map_tide";
+
+  // Datum frame names for tide range validation
+  std::string chart_datum_frame_ = "chart_datum";
+  std::string mhhw_frame_ = "chart_datum_mhhw";
+
+  // Multiplier on tidal range for rejection margin.
+  // 2.0 means accept up to 2x the tidal range beyond MHHW/below MLLW
+  // (accounts for storm surge, extreme tides).
+  double tide_range_margin_ = 2.0;
 
   // TODO: figure out the transform between the frame id in the odom
   // message nad the water line. Easy hack is to use a parameter for a
@@ -106,6 +177,8 @@ private:
   // transform listener.
 
   std::shared_ptr<tf2_ros::TransformBroadcaster> transform_broadcaster_;
+  std::shared_ptr<tf2_ros::Buffer> tf_buffer_;
+  std::shared_ptr<tf2_ros::TransformListener> tf_listener_;
 };
 
 int main(int argc, char * argv[])

--- a/mru_transform/nodes/sea_surface_estimator.cpp
+++ b/mru_transform/nodes/sea_surface_estimator.cpp
@@ -39,6 +39,13 @@ public:
 
     declare_parameter("tide_range_margin", tide_range_margin_);
     get_parameter("tide_range_margin", tide_range_margin_);
+    if (tide_range_margin_ < 0.0) {
+      RCLCPP_WARN(
+        get_logger(),
+        "Parameter 'tide_range_margin' is negative (%f); clamping to 0.0",
+        tide_range_margin_);
+      tide_range_margin_ = 0.0;
+    }
 
     transform_broadcaster_ = std::make_shared<tf2_ros::TransformBroadcaster>(*this);
 

--- a/mru_transform/nodes/sea_surface_estimator.cpp
+++ b/mru_transform/nodes/sea_surface_estimator.cpp
@@ -5,6 +5,7 @@
 #include "rclcpp_lifecycle/lifecycle_node.hpp"
 #include "lifecycle_msgs/msg/state.hpp"
 #include "nav_msgs/msg/odometry.hpp"
+#include "std_msgs/msg/float64.hpp"
 #include "tf2_ros/buffer.h"
 #include "tf2_ros/transform_broadcaster.h"
 #include "tf2_ros/transform_listener.h"
@@ -43,6 +44,10 @@ public:
 
     tf_buffer_ = std::make_shared<tf2_ros::Buffer>(get_clock());
     tf_listener_ = std::make_shared<tf2_ros::TransformListener>(*tf_buffer_);
+
+    auto latched_qos = rclcpp::QoS(1).transient_local();
+    tide_estimate_pub_ = create_publisher<std_msgs::msg::Float64>(
+      "tide_estimate", latched_qos);
 
     odometry_subscription_ = create_subscription<nav_msgs::msg::Odometry>(
       "odom", 10, std::bind(&SeaSurfaceEstimator::odometry_callback, this, std::placeholders::_1));
@@ -108,6 +113,10 @@ public:
     transform.transform.rotation.w = 1.0;
 
     transform_broadcaster_->sendTransform(transform);
+
+    std_msgs::msg::Float64 tide_msg;
+    tide_msg.data = average;
+    tide_estimate_pub_->publish(tide_msg);
   }
 
 private:
@@ -177,6 +186,7 @@ private:
   // transform listener.
 
   std::shared_ptr<tf2_ros::TransformBroadcaster> transform_broadcaster_;
+  rclcpp_lifecycle::LifecyclePublisher<std_msgs::msg::Float64>::SharedPtr tide_estimate_pub_;
   std::shared_ptr<tf2_ros::Buffer> tf_buffer_;
   std::shared_ptr<tf2_ros::TransformListener> tf_listener_;
 };

--- a/mru_transform/package.xml
+++ b/mru_transform/package.xml
@@ -22,6 +22,7 @@
   <depend>tf2_geometry_msgs</depend>
   <depend>tf2_msgs</depend>
   <depend>tf2_ros</depend>
+  <depend>std_msgs</depend>
 
   <depend>proj</depend>
 


### PR DESCRIPTION
## Summary

- **chart_datum_node**: Add second PROJ pipeline for MHHW (Mean Higher High Water). Publishes `map → chart_datum_mhhw` TF frame alongside existing MLLW frame. Both offsets also published as latched Float64 topics (`mllw_offset`, `mhhw_offset`) for debugging. MHHW is optional — degrades gracefully if grids are missing.
- **sea_surface_estimator**: Look up MLLW and MHHW frames to compute plausible tidal range. Suppress `map_tide` transform when estimated water level exceeds `MHHW + margin` (configurable, default 2x tidal range). Publish `tide_estimate` as latched Float64 topic.
- **CMakeLists.txt**: Extract and install `*_mhhw.gtx` grids from VDatum archive. Handle upgrade from older caches that only have MLLW.

Closes #15

## Test plan

- [ ] Build mru_transform — verified locally
- [ ] Verify chart_datum_node publishes both `chart_datum` and `chart_datum_mhhw` TF frames
- [ ] Verify `mllw_offset` and `mhhw_offset` topics are latched and show correct values
- [ ] Verify sea_surface_estimator suppresses `map_tide` when boat is out of water (Z above MHHW + margin)
- [ ] Verify normal operation is unaffected when tide estimate is within range
- [ ] Verify graceful degradation when MHHW grids are not available

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.6`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
