### PR TITLE
Rotate twist linear+angular+covariance into base_frame (REP-105)

### DIFF
--- a/.agent/work-plans/PLAN_ISSUE-18.md
+++ b/.agent/work-plans/PLAN_ISSUE-18.md
@@ -81,7 +81,7 @@ Design agreed on the issue (comment 4292978963):
 | `mru_transform/src/orientation_sensor.cpp` | `RCLCPP_WARN_ONCE` in quaternion + geopose callbacks |
 | `mru_transform/CMakeLists.txt` | Enable gtest in `BUILD_TESTING` block, link test target |
 | `mru_transform/package.xml` | Add `ament_cmake_gtest` test dependency |
-| `mru_transform/test/test_frame_rotation.cpp` *(new)* | Unit tests for all four rotation scenarios |
+| `mru_transform/test/test_twist_rotation.cpp` *(new)* | Unit tests for all four rotation scenarios |
 
 ## Principles Self-Check
 

--- a/.agent/work-plans/PLAN_ISSUE-18.md
+++ b/.agent/work-plans/PLAN_ISSUE-18.md
@@ -34,28 +34,38 @@ Design agreed on the issue (comment 4292978963):
 
 1. **Add tf2 buffer/listener to `MRUTransform`** — new member fields in
    `mru_transform.hpp`, initialized in the constructor alongside the
-   existing `TransformBroadcaster`. Use the node clock.
-2. **Refactor `updateVelocity`** (`mru_transform.cpp:135`):
+   existing `TransformBroadcaster`. Construct the buffer with
+   `node_->get_clock()` so it honors sim time (important because the
+   simulation pipeline consumers `asv_helm` + `ben_gazebo` run under
+   simulated time and are primary beneficiaries of this fix).
+2. **Change `VelocitySensor::ValueType` to `TwistWithCovarianceStamped`**
+   (`velocity_sensor.hpp`, `velocity_sensor.cpp`). Today the sensor
+   discards covariance when unwrapping `TwistWithCovarianceStamped` →
+   `TwistStamped`. Preserving covariance end-to-end is required for
+   the rotation work below to have any effect on `TwistWithCovariance`
+   inputs. The plain `TwistStamped` subscription path fills a zero
+   covariance block.
+3. **Refactor `updateVelocity`** (`mru_transform.cpp:135`):
    - Resolve TF `base_frame_ ← velocity.header.frame_id` at `velocity.header.stamp`.
    - On lookup failure, `RCLCPP_WARN_THROTTLE` (5 s) and return without publishing.
-   - Rotate `velocity.twist.linear` into body via the lookup's rotation component.
+   - Rotate `velocity.twist.twist.linear` into body via the lookup's rotation component.
    - Rotate the 3×3 linear-covariance sub-block of `velocity.twist.covariance`
      as `R Σ Rᵀ` and write into `odom_.twist.covariance[0..2,0..2]`.
-3. **Refactor `updateOrientation`** (`mru_transform.cpp:approx-130`, IMU path):
+4. **Refactor `updateOrientation`** (`mru_transform.cpp:approx-130`, IMU path):
    - Same TF lookup keyed on `imu.header.frame_id`.
    - Rotate `angular_velocity` and the 3×3 angular-covariance block (indices 3..5).
    - No change to `odom_.pose.pose.orientation` — still the raw world-frame quaternion.
-4. **Add warnings to `OrientationSensor` non-IMU callbacks**
+5. **Add warnings to `OrientationSensor` non-IMU callbacks**
    (`orientation_sensor.cpp:53,60`): `RCLCPP_WARN_ONCE` saying
    "angular_velocity not available from QuaternionStamped / GeoPoseStamped".
-5. **Add gtest-based unit tests** under `mru_transform/test/`:
+6. **Add gtest-based unit tests** under `mru_transform/test/`:
    - Synthetic ENU velocity + known orientation → assert rotated linear matches hand-computed.
    - Synthetic gyro in a rotated sensor frame → assert rotated angular matches.
    - Both with non-diagonal covariance → assert `R Σ Rᵀ` block-diagonal output.
    - TF-missing case → assert no publish + warn log observed.
-6. **Update CMakeLists / package.xml** to enable `gtest` + declare
+7. **Update CMakeLists / package.xml** to enable `gtest` + declare
    `<test_depend>ament_cmake_gtest</test_depend>`.
-7. **Manual bag regression** (not automated, documented in PR description):
+8. **Manual bag regression** (not automated, documented in PR description):
    replay a bizzyboat bag, confirm magnitude preserved and
    `rotate(odom.twist.linear, +yaw_enu) ≈ gps_vel.twist.linear` with no
    heading-dependent residual.
@@ -65,7 +75,9 @@ Design agreed on the issue (comment 4292978963):
 | File | Change |
 |---|---|
 | `mru_transform/include/mru_transform/mru_transform.hpp` | Add `tf2_ros::Buffer` + `TransformListener` members |
-| `mru_transform/src/mru_transform.cpp` | Refactor `updateVelocity` + `updateOrientation`; initialize tf2 buffer/listener |
+| `mru_transform/include/mru_transform/velocity_sensor.hpp` | Change `VelocitySensor` base type to `TwistWithCovarianceStamped` |
+| `mru_transform/src/velocity_sensor.cpp` | Zero-fill covariance on `TwistStamped` input path; forward covariance on `TwistWithCovarianceStamped` path |
+| `mru_transform/src/mru_transform.cpp` | Refactor `updateVelocity` + `updateOrientation`; initialize tf2 buffer/listener with `node_->get_clock()` |
 | `mru_transform/src/orientation_sensor.cpp` | `RCLCPP_WARN_ONCE` in quaternion + geopose callbacks |
 | `mru_transform/CMakeLists.txt` | Enable gtest in `BUILD_TESTING` block, link test target |
 | `mru_transform/package.xml` | Add `ament_cmake_gtest` test dependency |
@@ -81,10 +93,14 @@ Design agreed on the issue (comment 4292978963):
 
 ## ADR Compliance
 
-No workspace-level ADRs are directly triggered — this is a REP-105 alignment
-in a project repo. No project-level governance file exists in
-`rolker/mru_transform` (no `AGENTS.md` or `.agent/` at repo root beyond the
-new work-plans directory).
+| ADR | Triggered | How addressed |
+|---|---|---|
+| ADR-0008 — Follow ROS 2 Official Conventions | Yes (modifies `package.xml`, `CMakeLists.txt`, adds test files) | Complies: standard `ament_cmake_gtest` for tests, `<test_depend>` placement, REP-105 is precisely the convention being aligned to |
+| ADR-0002 — Worktree isolation | Yes (any feature work) | Satisfied: work happens in `layers/worktrees/issue-mru_transform-18` |
+
+No other workspace-level ADRs apply. No project-level governance file
+exists in `rolker/mru_transform` (no `AGENTS.md` or `.agent/` at repo root
+beyond the new work-plans directory).
 
 ## Consequences
 
@@ -93,6 +109,8 @@ new work-plans directory).
 | `odom.twist.linear` frame | Downstream speed-PID consumers (`asv_helm`, `ben_gazebo`) | No — those consumers become correct automatically once mru_transform is fixed; no code change needed in them. Note in PR description for verification. |
 | `odom.twist.covariance` block | EKF/robot_localization consumers reading it | No downstream consumers identified in workspace grep; ships as-is |
 | Added `tf2_ros::TransformListener` | Node QoS / thread model | Standard add, matches existing broadcaster pattern |
+| TF lookup keyed on `velocity.header.frame_id` | **`rolker/posmv` users** — posmv publishes with `header.frame_id = posmv_frame` (user-configured). After this fix, a static TF from `posmv_frame` → world frame must exist in the TF tree, or velocity messages drop with `WARN_THROTTLE`. | Documented in PR description as deployment note — not a regression (this is correct REP-105 behavior), but an operational change for existing posmv users. |
+| `VelocitySensor::ValueType` change from `TwistStamped` → `TwistWithCovarianceStamped` | Internal to mru_transform — changes signature of `MRUTransform::updateVelocity` | Included in plan step 2 |
 
 ## Open Questions
 
@@ -101,4 +119,5 @@ explicit go-ahead.
 
 ## Estimated Scope
 
-Single PR. ~150-250 lines of change including tests.
+Single PR. Mid-hundreds of lines (230-300) including the gtest suite with
+hand-computed covariance rotations.

--- a/.agent/work-plans/PLAN_ISSUE-18.md
+++ b/.agent/work-plans/PLAN_ISSUE-18.md
@@ -1,0 +1,104 @@
+# Plan: odom.twist.linear published in world frame, not body frame (REP-105)
+
+## Issue
+
+https://github.com/rolker/mru_transform/issues/18
+
+## Context
+
+`MRUTransform::updateVelocity` copies the incoming world-frame velocity
+verbatim into `nav_msgs/Odometry.twist.twist.linear`, which per REP-105
+must be expressed in `child_frame_id` (body frame). Same latent pattern
+applies to `updateOrientation`'s angular-velocity copy and to the
+covariance matrix.
+
+Field evidence (BizzyBoat 2026-04-21, ~50k samples): correlation between
+`/bizzy/odom.twist.linear` and `/bizzy/mavros/.../gps_vel.twist.linear`
+is 1.0000 with median diff 0.0 mm/s — literally the same ENU signal.
+
+Downstream consumers `asv_helm_node.cpp` and `ben_gazebo/gazebo_helm_node.cpp`
+feed `odom.twist.linear.x` into a speed PID as body-forward feedback; when
+the vessel heading ≠ due east, the PID feedback is silently rotated and the
+controller misbehaves. BizzyBoat is not affected in the field because
+`echo_helm` doesn't close a loop on `odom.twist`, but the sim graph is
+affected and any future consumer trusting REP-105 will be too.
+
+Design agreed on the issue (comment 4292978963):
+- Rotate linear, angular, and the full 6×6 `twist.covariance` block-diagonal.
+- Drive rotations by tf2 lookups keyed on each message's `header.frame_id`.
+- TF lookup failure → drop message + `RCLCPP_WARN_THROTTLE` at 5 s.
+- Emit `RCLCPP_WARN_ONCE` in `OrientationSensor`'s `QuaternionStamped` and
+  `GeoPoseStamped` callbacks noting `angular_velocity` is unavailable there.
+
+## Approach
+
+1. **Add tf2 buffer/listener to `MRUTransform`** — new member fields in
+   `mru_transform.hpp`, initialized in the constructor alongside the
+   existing `TransformBroadcaster`. Use the node clock.
+2. **Refactor `updateVelocity`** (`mru_transform.cpp:135`):
+   - Resolve TF `base_frame_ ← velocity.header.frame_id` at `velocity.header.stamp`.
+   - On lookup failure, `RCLCPP_WARN_THROTTLE` (5 s) and return without publishing.
+   - Rotate `velocity.twist.linear` into body via the lookup's rotation component.
+   - Rotate the 3×3 linear-covariance sub-block of `velocity.twist.covariance`
+     as `R Σ Rᵀ` and write into `odom_.twist.covariance[0..2,0..2]`.
+3. **Refactor `updateOrientation`** (`mru_transform.cpp:approx-130`, IMU path):
+   - Same TF lookup keyed on `imu.header.frame_id`.
+   - Rotate `angular_velocity` and the 3×3 angular-covariance block (indices 3..5).
+   - No change to `odom_.pose.pose.orientation` — still the raw world-frame quaternion.
+4. **Add warnings to `OrientationSensor` non-IMU callbacks**
+   (`orientation_sensor.cpp:53,60`): `RCLCPP_WARN_ONCE` saying
+   "angular_velocity not available from QuaternionStamped / GeoPoseStamped".
+5. **Add gtest-based unit tests** under `mru_transform/test/`:
+   - Synthetic ENU velocity + known orientation → assert rotated linear matches hand-computed.
+   - Synthetic gyro in a rotated sensor frame → assert rotated angular matches.
+   - Both with non-diagonal covariance → assert `R Σ Rᵀ` block-diagonal output.
+   - TF-missing case → assert no publish + warn log observed.
+6. **Update CMakeLists / package.xml** to enable `gtest` + declare
+   `<test_depend>ament_cmake_gtest</test_depend>`.
+7. **Manual bag regression** (not automated, documented in PR description):
+   replay a bizzyboat bag, confirm magnitude preserved and
+   `rotate(odom.twist.linear, +yaw_enu) ≈ gps_vel.twist.linear` with no
+   heading-dependent residual.
+
+## Files to Change
+
+| File | Change |
+|---|---|
+| `mru_transform/include/mru_transform/mru_transform.hpp` | Add `tf2_ros::Buffer` + `TransformListener` members |
+| `mru_transform/src/mru_transform.cpp` | Refactor `updateVelocity` + `updateOrientation`; initialize tf2 buffer/listener |
+| `mru_transform/src/orientation_sensor.cpp` | `RCLCPP_WARN_ONCE` in quaternion + geopose callbacks |
+| `mru_transform/CMakeLists.txt` | Enable gtest in `BUILD_TESTING` block, link test target |
+| `mru_transform/package.xml` | Add `ament_cmake_gtest` test dependency |
+| `mru_transform/test/test_frame_rotation.cpp` *(new)* | Unit tests for all four rotation scenarios |
+
+## Principles Self-Check
+
+| Principle | Consideration |
+|---|---|
+| Correctness over convenience | Fix the frame bug properly (rotate everything) rather than papering over with a magnitude-only workaround |
+| Fail loudly, not silently | TF failure logs via `WARN_THROTTLE`; non-IMU orientation sources now surface a `WARN_ONCE` instead of publishing zero/stale `angular_velocity` |
+| Tests accompany fixes | New gtest coverage ships with the PR, not as a follow-up |
+
+## ADR Compliance
+
+No workspace-level ADRs are directly triggered — this is a REP-105 alignment
+in a project repo. No project-level governance file exists in
+`rolker/mru_transform` (no `AGENTS.md` or `.agent/` at repo root beyond the
+new work-plans directory).
+
+## Consequences
+
+| If we change... | Also update... | Included in plan? |
+|---|---|---|
+| `odom.twist.linear` frame | Downstream speed-PID consumers (`asv_helm`, `ben_gazebo`) | No — those consumers become correct automatically once mru_transform is fixed; no code change needed in them. Note in PR description for verification. |
+| `odom.twist.covariance` block | EKF/robot_localization consumers reading it | No downstream consumers identified in workspace grep; ships as-is |
+| Added `tf2_ros::TransformListener` | Node QoS / thread model | Standard add, matches existing broadcaster pattern |
+
+## Open Questions
+
+None — design settled in issue discussion. Proceed to implementation on
+explicit go-ahead.
+
+## Estimated Scope
+
+Single PR. ~150-250 lines of change including tests.

--- a/mru_transform/CMakeLists.txt
+++ b/mru_transform/CMakeLists.txt
@@ -292,6 +292,16 @@ endforeach()
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
   ament_lint_auto_find_test_dependencies()
+
+  find_package(ament_cmake_gtest REQUIRED)
+  ament_add_gtest(test_twist_rotation test/test_twist_rotation.cpp)
+  target_link_libraries(test_twist_rotation
+    ${PROJECT_NAME}
+    tf2::tf2
+  )
+  target_include_directories(test_twist_rotation PRIVATE
+    "${CMAKE_CURRENT_SOURCE_DIR}/include"
+  )
 endif()
 
 ament_package()

--- a/mru_transform/include/mru_transform/mru_transform.hpp
+++ b/mru_transform/include/mru_transform/mru_transform.hpp
@@ -1,8 +1,14 @@
 #ifndef MRU_TRANSFORM_MRU_TRANSFORM_H
 #define MRU_TRANSFORM_MRU_TRANSFORM_H
 
+#include <array>
+#include <mutex>
+
 #include "rclcpp/rclcpp.hpp"
 #include "nav_msgs/msg/odometry.hpp"
+#include "geometry_msgs/msg/point.hpp"
+#include "geometry_msgs/msg/quaternion.hpp"
+#include "geometry_msgs/msg/vector3.hpp"
 #include "std_msgs/msg/string.hpp"
 #include "mru_transform/navigation_sensors.hpp"
 #include "mru_transform/map_frame.hpp"
@@ -36,14 +42,25 @@ private:
   std::shared_ptr<MapFrame> mapFrame_;
   std::shared_ptr<tf2_ros::TransformBroadcaster> broadcaster_;
   rclcpp::Publisher<nav_msgs::msg::Odometry>::SharedPtr odom_pub_;
-  nav_msgs::msg::Odometry odom_;
+
+  // State contributed by each sensor callback, guarded by state_mu_.
+  // updateVelocity composes a fresh nav_msgs/Odometry from this snapshot
+  // and publishes.  Design goal: callbacks can safely run concurrently
+  // under a MultiThreadedExecutor (no shared nav_msgs::msg::Odometry
+  // member being mutated from three threads).
+  std::mutex state_mu_;
+  bool have_position_{false};
+  bool have_orientation_{false};
+  geometry_msgs::msg::Point latest_position_map_;     // set by updatePosition
+  geometry_msgs::msg::Quaternion latest_orientation_; // set by updateOrientation
+  geometry_msgs::msg::Vector3 latest_angular_body_;   // set by updateOrientation (rotated)
+  std::array<double, 9> latest_angular_cov_body_{};   // row-major 3x3; set by updateOrientation
 
   rclcpp::Node::SharedPtr node_;
   rclcpp::Service<std_srvs::srv::Trigger>::SharedPtr reset_map_frame_service_;
-  
+
   std::shared_ptr<tf2_ros::TransformListener> tf_listener_{nullptr};
   std::unique_ptr<tf2_ros::Buffer> tf_buffer_;
-
 };
 
 } // namespace mru_transform

--- a/mru_transform/include/mru_transform/twist_rotation_utils.hpp
+++ b/mru_transform/include/mru_transform/twist_rotation_utils.hpp
@@ -3,7 +3,6 @@
 
 #include <array>
 #include <tf2/LinearMath/Matrix3x3.h>
-#include <tf2/LinearMath/Vector3.h>
 
 namespace mru_transform
 {

--- a/mru_transform/include/mru_transform/twist_rotation_utils.hpp
+++ b/mru_transform/include/mru_transform/twist_rotation_utils.hpp
@@ -16,6 +16,16 @@ namespace mru_transform
 //
 // block_offset = 0: upper-left 3x3 (linear velocity block)
 // block_offset = 3: lower-right 3x3 (angular velocity block)
+//
+// Scope note: this helper handles diagonal blocks only.  The off-diagonal
+// 3x3 blocks at (0, 3) and (3, 0) — cross-covariance between linear and
+// angular velocity — are NOT rotated.  For current known sources
+// (mavros gps_vel, posmv, asv_sim) those cross-blocks are always zero
+// because linear and angular velocity come from independent sensors, so
+// in practice nothing is lost.  If a future source provides non-zero
+// cross-covariance (e.g., a fused INS reporting a full 6x6), this
+// helper's output will silently zero those blocks.  See
+// rolker/mru_transform#18 review discussion.
 inline void rotate_covariance_block_3x3(
   const std::array<double, 36> &covariance_in,
   const tf2::Matrix3x3 &R,

--- a/mru_transform/include/mru_transform/twist_rotation_utils.hpp
+++ b/mru_transform/include/mru_transform/twist_rotation_utils.hpp
@@ -1,0 +1,43 @@
+#ifndef MRU_TRANSFORM_TWIST_ROTATION_UTILS_HPP
+#define MRU_TRANSFORM_TWIST_ROTATION_UTILS_HPP
+
+#include <array>
+#include <tf2/LinearMath/Matrix3x3.h>
+#include <tf2/LinearMath/Vector3.h>
+
+namespace mru_transform
+{
+
+// Rotate a 3x3 covariance sub-block embedded at offset (block_offset,
+// block_offset) within a 6x6 covariance matrix stored row-major as
+// std::array<double, 36>.  Computes Sigma_out = R * Sigma_in * R^T on
+// the indicated block, writing back into `covariance_out` at the same
+// offset.  Other blocks of covariance_out are left untouched.
+//
+// block_offset = 0: upper-left 3x3 (linear velocity block)
+// block_offset = 3: lower-right 3x3 (angular velocity block)
+inline void rotate_covariance_block_3x3(
+  const std::array<double, 36> &covariance_in,
+  const tf2::Matrix3x3 &R,
+  int block_offset,
+  std::array<double, 36> &covariance_out)
+{
+  tf2::Matrix3x3 Sigma_in;
+  for (int i = 0; i < 3; ++i) {
+    for (int j = 0; j < 3; ++j) {
+      Sigma_in[i][j] =
+        covariance_in[(block_offset + i) * 6 + (block_offset + j)];
+    }
+  }
+  const tf2::Matrix3x3 Sigma_out = R * Sigma_in * R.transpose();
+  for (int i = 0; i < 3; ++i) {
+    for (int j = 0; j < 3; ++j) {
+      covariance_out[(block_offset + i) * 6 + (block_offset + j)] =
+        Sigma_out[i][j];
+    }
+  }
+}
+
+} // namespace mru_transform
+
+#endif

--- a/mru_transform/include/mru_transform/twist_rotation_utils.hpp
+++ b/mru_transform/include/mru_transform/twist_rotation_utils.hpp
@@ -12,20 +12,24 @@ namespace mru_transform
 // block_offset) within a 6x6 covariance matrix stored row-major as
 // std::array<double, 36>.  Computes Sigma_out = R * Sigma_in * R^T on
 // the indicated block, writing back into `covariance_out` at the same
-// offset.  Other blocks of covariance_out are left untouched.
+// offset.  **Other blocks of `covariance_out` are left untouched** —
+// callers are responsible for initializing/clearing the rest of the
+// output array as needed (e.g., zero-init a fresh array, or clear the
+// off-diagonal blocks explicitly if the input had stale data there).
 //
 // block_offset = 0: upper-left 3x3 (linear velocity block)
 // block_offset = 3: lower-right 3x3 (angular velocity block)
 //
 // Scope note: this helper handles diagonal blocks only.  The off-diagonal
 // 3x3 blocks at (0, 3) and (3, 0) — cross-covariance between linear and
-// angular velocity — are NOT rotated.  For current known sources
-// (mavros gps_vel, posmv, asv_sim) those cross-blocks are always zero
-// because linear and angular velocity come from independent sensors, so
-// in practice nothing is lost.  If a future source provides non-zero
-// cross-covariance (e.g., a fused INS reporting a full 6x6), this
-// helper's output will silently zero those blocks.  See
-// rolker/mru_transform#18 review discussion.
+// angular velocity — are NOT rotated and are not touched in
+// `covariance_out`.  For current known sources (mavros gps_vel, posmv,
+// asv_sim) those cross-blocks are always zero because linear and angular
+// velocity come from independent sensors, so in practice nothing is lost.
+// If a future source provides non-zero cross-covariance (e.g., a fused
+// INS reporting a full 6x6), the caller must preserve or clear those
+// blocks explicitly in `covariance_out`.  See rolker/mru_transform#18
+// review discussion.
 inline void rotate_covariance_block_3x3(
   const std::array<double, 36> &covariance_in,
   const tf2::Matrix3x3 &R,

--- a/mru_transform/include/mru_transform/velocity_sensor.hpp
+++ b/mru_transform/include/mru_transform/velocity_sensor.hpp
@@ -8,7 +8,10 @@
 namespace mru_transform
 {
 
-class VelocitySensor: public SensorBase<geometry_msgs::msg::TwistStamped>
+// Uses TwistWithCovarianceStamped as its value type so covariance is
+// preserved end-to-end for REP-105-compliant downstream consumers.  The
+// plain TwistStamped subscription path fills a zero covariance block.
+class VelocitySensor: public SensorBase<geometry_msgs::msg::TwistWithCovarianceStamped>
 {
 public:
   VelocitySensor(NodeInterfaces node, std::string name, CallbackType callback);

--- a/mru_transform/package.xml
+++ b/mru_transform/package.xml
@@ -26,6 +26,8 @@
 
   <depend>proj</depend>
 
+  <test_depend>ament_cmake_gtest</test_depend>
+
   <!-- The export tag contains other, unspecified, tags -->
   <export>
     <build_type>ament_cmake</build_type>

--- a/mru_transform/src/mru_transform.cpp
+++ b/mru_transform/src/mru_transform.cpp
@@ -289,6 +289,12 @@ void MRUTransform::updateVelocity(const VelocitySensor::ValueType &velocity)
   odom.header.frame_id = odom_frame_;
   odom.header.stamp = velocity.header.stamp;
   odom.child_frame_id = base_frame_;
+  // Identity quaternion as the fallback pose orientation in case no
+  // orientation sample has been received yet.  The default-constructed
+  // quaternion is all-zero and invalid (non-unit); consumers that normalize
+  // or rotate by this field can misbehave.  Overwritten below when
+  // have_orientation_ is true.
+  odom.pose.pose.orientation.w = 1.0;
   odom.twist.twist.linear = linear_body;
 
   // Rotate linear-covariance sub-block (upper-left 3x3).  Cross-covariance

--- a/mru_transform/src/mru_transform.cpp
+++ b/mru_transform/src/mru_transform.cpp
@@ -1,4 +1,5 @@
 #include "mru_transform/mru_transform.hpp"
+#include "mru_transform/twist_rotation_utils.hpp"
 
 #include <sensor_msgs/msg/nav_sat_fix.hpp>
 #include <sensor_msgs/msg/imu.hpp>
@@ -129,7 +130,59 @@ void MRUTransform::updateOrientation(const OrientationSensor::ValueType &orienta
   broadcaster_->sendTransform(transforms);
 
   odom_.pose.pose.orientation = orientation.orientation;
+
+  // REP-105: angular velocity must be expressed in child_frame_id (body).
+  // IMU-sourced gyro is in orientation.header.frame_id (typically the IMU's
+  // physical frame).  Rotate into body frame using the static sensor-to-base
+  // transform.  No-op when frame_id already matches base_frame_.
+  if (!orientation.header.frame_id.empty() &&
+      orientation.header.frame_id != base_frame_)
+  {
+    try {
+      auto tf = tf_buffer_->lookupTransform(
+        base_frame_, orientation.header.frame_id, tf2::TimePointZero);
+      tf2::Quaternion q;
+      tf2::fromMsg(tf.transform.rotation, q);
+      tf2::Matrix3x3 R(q);
+
+      tf2::Vector3 w_in(orientation.angular_velocity.x,
+                        orientation.angular_velocity.y,
+                        orientation.angular_velocity.z);
+      tf2::Vector3 w_out = R * w_in;
+      odom_.twist.twist.angular.x = w_out.x();
+      odom_.twist.twist.angular.y = w_out.y();
+      odom_.twist.twist.angular.z = w_out.z();
+
+      // Rotate angular-covariance sub-block.  The source (sensor_msgs/Imu)
+      // stores angular_velocity_covariance as a flat 9-array; promote into a
+      // 36-array with the angular block populated, rotate, then copy back.
+      std::array<double, 36> cov_in_6x6{};
+      for (int i = 0; i < 3; ++i) {
+        for (int j = 0; j < 3; ++j) {
+          cov_in_6x6[(i + 3) * 6 + (j + 3)] =
+            orientation.angular_velocity_covariance[i * 3 + j];
+        }
+      }
+      rotate_covariance_block_3x3(cov_in_6x6, R, 3, odom_.twist.covariance);
+      return;
+    } catch (const tf2::TransformException &e) {
+      RCLCPP_WARN_THROTTLE(node_->get_logger(), *node_->get_clock(), 5000,
+        "orientation: TF '%s' -> '%s' lookup failed: %s (passing angular through unrotated — set up static TF to eliminate this warning)",
+        orientation.header.frame_id.c_str(), base_frame_.c_str(), e.what());
+      // Fall through to the unrotated path below rather than drop, since the
+      // orientation stream also drives pose TF broadcasts that callers may
+      // depend on.
+    }
+  }
+
+  // Same-frame (or post-exception fallback) path — copy angular directly.
   odom_.twist.twist.angular = orientation.angular_velocity;
+  for (int i = 0; i < 3; ++i) {
+    for (int j = 0; j < 3; ++j) {
+      odom_.twist.covariance[(i + 3) * 6 + (j + 3)] =
+        orientation.angular_velocity_covariance[i * 3 + j];
+    }
+  }
 }
 
 void MRUTransform::updateVelocity(const VelocitySensor::ValueType &velocity)
@@ -138,7 +191,40 @@ void MRUTransform::updateVelocity(const VelocitySensor::ValueType &velocity)
   odom_.header.stamp = velocity.header.stamp;
   odom_.child_frame_id = base_frame_;
 
-  odom_.twist.twist.linear = velocity.twist.linear;
+  // REP-105: odom.twist must be expressed in child_frame_id (body).  Incoming
+  // velocity is in velocity.header.frame_id — typically a world frame (map,
+  // posmv_frame, mru_frame).  Rotate linear velocity + covariance into body
+  // before publishing.  No-op when frame_id already matches base_frame_.
+  geometry_msgs::msg::TransformStamped tf;
+  try {
+    tf = tf_buffer_->lookupTransform(
+      base_frame_, velocity.header.frame_id,
+      rclcpp::Time(velocity.header.stamp),
+      rclcpp::Duration::from_seconds(0.1));
+  } catch (const tf2::TransformException &e) {
+    RCLCPP_WARN_THROTTLE(node_->get_logger(), *node_->get_clock(), 5000,
+      "velocity: TF '%s' -> '%s' lookup failed: %s (dropping sample)",
+      velocity.header.frame_id.c_str(), base_frame_.c_str(), e.what());
+    return;
+  }
+
+  tf2::Quaternion q;
+  tf2::fromMsg(tf.transform.rotation, q);
+  tf2::Matrix3x3 R(q);
+
+  // Rotate linear velocity
+  tf2::Vector3 v_in(velocity.twist.twist.linear.x,
+                    velocity.twist.twist.linear.y,
+                    velocity.twist.twist.linear.z);
+  tf2::Vector3 v_out = R * v_in;
+  odom_.twist.twist.linear.x = v_out.x();
+  odom_.twist.twist.linear.y = v_out.y();
+  odom_.twist.twist.linear.z = v_out.z();
+
+  // Rotate linear-covariance sub-block (upper-left 3x3)
+  rotate_covariance_block_3x3(velocity.twist.covariance, R, 0,
+                              odom_.twist.covariance);
+
   odom_pub_->publish(odom_);
 }
 

--- a/mru_transform/src/mru_transform.cpp
+++ b/mru_transform/src/mru_transform.cpp
@@ -231,7 +231,11 @@ void MRUTransform::updateVelocity(const VelocitySensor::ValueType &velocity)
   // REP-105: odom.twist must be expressed in child_frame_id (body).  Incoming
   // velocity is in velocity.header.frame_id — typically a world frame (map,
   // posmv_frame, mru_frame).  Rotate linear velocity + covariance into body
-  // before publishing.  No-op when frame_id already matches base_frame_.
+  // before publishing.  The TF lookup always runs:
+  //   - when frame_id == base_frame_, it returns identity (rotation is a
+  //     mathematical no-op, so values pass through unchanged)
+  //   - when frame_id is empty or cannot be resolved in the TF tree,
+  //     lookupTransform throws → we WARN_THROTTLE and drop this sample.
   geometry_msgs::msg::TransformStamped tf;
   try {
     tf = tf_buffer_->lookupTransform(

--- a/mru_transform/src/mru_transform.cpp
+++ b/mru_transform/src/mru_transform.cpp
@@ -8,9 +8,11 @@
 #include <geometry_msgs/msg/transform_stamped.hpp>
 #include <std_srvs/srv/trigger.hpp> // Include the Trigger service header
 
+#include <tf2/LinearMath/Matrix3x3.h>
 #include <tf2/LinearMath/Quaternion.h>
-#include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
+#include <tf2/LinearMath/Vector3.h>
 #include <tf2/utils.h>
+#include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
 
 namespace mru_transform{
 
@@ -135,9 +137,19 @@ void MRUTransform::updateOrientation(const OrientationSensor::ValueType &orienta
   // IMU-sourced gyro is in orientation.header.frame_id (typically the IMU's
   // physical frame).  Rotate into body frame using the static sensor-to-base
   // transform.  No-op when frame_id already matches base_frame_.
-  if (!orientation.header.frame_id.empty() &&
-      orientation.header.frame_id != base_frame_)
-  {
+  //
+  // Failure-handling note: unlike updateVelocity (which drops the sample on
+  // TF lookup failure), this function still needs to run to broadcast the
+  // pose TFs above.  So on TF failure we publish zero angular velocity +
+  // zero angular covariance.  That is the honest representation when we
+  // cannot express the gyro in body frame: "no angular info available"
+  // rather than "angular info in an unknown frame".  The WARN_THROTTLE
+  // tells the operator to set up the missing static TF.
+  const bool same_frame =
+    orientation.header.frame_id.empty() ||
+    orientation.header.frame_id == base_frame_;
+
+  if (!same_frame) {
     try {
       auto tf = tf_buffer_->lookupTransform(
         base_frame_, orientation.header.frame_id, tf2::TimePointZero);
@@ -156,6 +168,8 @@ void MRUTransform::updateOrientation(const OrientationSensor::ValueType &orienta
       // Rotate angular-covariance sub-block.  The source (sensor_msgs/Imu)
       // stores angular_velocity_covariance as a flat 9-array; promote into a
       // 36-array with the angular block populated, rotate, then copy back.
+      // (Only the 3x3 angular-diagonal sub-block is rotated — see
+      //  twist_rotation_utils.hpp for the helper's scope.)
       std::array<double, 36> cov_in_6x6{};
       for (int i = 0; i < 3; ++i) {
         for (int j = 0; j < 3; ++j) {
@@ -167,15 +181,19 @@ void MRUTransform::updateOrientation(const OrientationSensor::ValueType &orienta
       return;
     } catch (const tf2::TransformException &e) {
       RCLCPP_WARN_THROTTLE(node_->get_logger(), *node_->get_clock(), 5000,
-        "orientation: TF '%s' -> '%s' lookup failed: %s (passing angular through unrotated — set up static TF to eliminate this warning)",
+        "orientation: TF '%s' -> '%s' lookup failed: %s (publishing zero angular — set up a static TF to eliminate this warning)",
         orientation.header.frame_id.c_str(), base_frame_.c_str(), e.what());
-      // Fall through to the unrotated path below rather than drop, since the
-      // orientation stream also drives pose TF broadcasts that callers may
-      // depend on.
+      odom_.twist.twist.angular = geometry_msgs::msg::Vector3();
+      for (int i = 0; i < 3; ++i) {
+        for (int j = 0; j < 3; ++j) {
+          odom_.twist.covariance[(i + 3) * 6 + (j + 3)] = 0.0;
+        }
+      }
+      return;
     }
   }
 
-  // Same-frame (or post-exception fallback) path — copy angular directly.
+  // Same-frame path (frame_id is base_frame_ or empty) — copy angular directly.
   odom_.twist.twist.angular = orientation.angular_velocity;
   for (int i = 0; i < 3; ++i) {
     for (int j = 0; j < 3; ++j) {
@@ -221,7 +239,9 @@ void MRUTransform::updateVelocity(const VelocitySensor::ValueType &velocity)
   odom_.twist.twist.linear.y = v_out.y();
   odom_.twist.twist.linear.z = v_out.z();
 
-  // Rotate linear-covariance sub-block (upper-left 3x3)
+  // Rotate linear-covariance sub-block (upper-left 3x3).  Cross-covariance
+  // blocks between linear and angular are not touched — see the scope note
+  // in twist_rotation_utils.hpp.
   rotate_covariance_block_3x3(velocity.twist.covariance, R, 0,
                               odom_.twist.covariance);
 

--- a/mru_transform/src/mru_transform.cpp
+++ b/mru_transform/src/mru_transform.cpp
@@ -110,9 +110,19 @@ void MRUTransform::updatePosition(PositionSensor::ValueType position)
 
 void MRUTransform::updateOrientation(const OrientationSensor::ValueType &orientation)
 {
-  tf2::Quaternion orientation_quat;
+  // Sanitize an all-zero (uninitialized) orientation quaternion to identity
+  // once, up front, so the same value flows to both the TF broadcast and the
+  // stored latest_orientation_ used in the published odom.  An all-zero quat
+  // is invalid (not unit length) and would confuse downstream consumers of
+  // odom.pose.pose.orientation.
+  geometry_msgs::msg::Quaternion orientation_q = orientation.orientation;
+  if (orientation_q.x == 0.0 && orientation_q.y == 0.0 &&
+      orientation_q.z == 0.0 && orientation_q.w == 0.0) {
+    orientation_q.w = 1.0;
+  }
 
-  tf2::fromMsg(orientation.orientation, orientation_quat);
+  tf2::Quaternion orientation_quat;
+  tf2::fromMsg(orientation_q, orientation_quat);
 
   double roll,pitch,yaw;
   tf2::getEulerYPR(orientation_quat, yaw, pitch, roll);
@@ -127,15 +137,12 @@ void MRUTransform::updateOrientation(const OrientationSensor::ValueType &orienta
 
   std::vector<geometry_msgs::msg::TransformStamped> transforms;
   transforms.push_back(north_up_base_link_to_level_base_link);
-  
+
   geometry_msgs::msg::TransformStamped north_up_base_link_to_base_link;
   north_up_base_link_to_base_link.header.stamp = orientation.header.stamp;
   north_up_base_link_to_base_link.header.frame_id = base_frame_+"_north_up";
   north_up_base_link_to_base_link.child_frame_id = base_frame_;
-  north_up_base_link_to_base_link.transform.rotation = orientation.orientation;
-  // if we have an uninitialized quat, lets set it to identity
-  if(orientation.orientation.x == 0.0 && orientation.orientation.y == 0.0 && orientation.orientation.z == 0 && orientation.orientation.w == 0.0)
-    north_up_base_link_to_base_link.transform.rotation.w = 1.0;
+  north_up_base_link_to_base_link.transform.rotation = orientation_q;
   transforms.push_back(north_up_base_link_to_base_link);
   broadcaster_->sendTransform(transforms);
 
@@ -217,7 +224,7 @@ void MRUTransform::updateOrientation(const OrientationSensor::ValueType &orienta
 
   {
     std::lock_guard<std::mutex> lock(state_mu_);
-    latest_orientation_ = orientation.orientation;
+    latest_orientation_ = orientation_q;
     if (have_angular) {
       latest_angular_body_ = angular_body;
       latest_angular_cov_body_ = angular_cov_body;

--- a/mru_transform/src/mru_transform.cpp
+++ b/mru_transform/src/mru_transform.cpp
@@ -165,12 +165,22 @@ void MRUTransform::updateOrientation(const OrientationSensor::ValueType &orienta
   geometry_msgs::msg::Vector3 angular_body;
   std::array<double, 9> angular_cov_body{};
 
-  const bool same_frame =
-    orientation.header.frame_id.empty() ||
-    orientation.header.frame_id == base_frame_;
+  // Empty frame_id is a publisher bug (not a signal that the data is already
+  // in base_frame_).  Treat it like a TF failure — align with updateVelocity
+  // which drops samples with empty/unresolvable frame_id.  Publishes zero
+  // angular rather than copying sensor-frame values through as body-frame.
+  const bool same_frame = orientation.header.frame_id == base_frame_;
+  const bool empty_frame = orientation.header.frame_id.empty();
 
   bool have_angular = false;
-  if (!same_frame) {
+  if (empty_frame) {
+    RCLCPP_WARN_THROTTLE(node_->get_logger(), *node_->get_clock(), 5000,
+      "orientation: empty header.frame_id; cannot express angular velocity "
+      "in '%s' (publishing zero angular — fix the IMU publisher's frame_id)",
+      base_frame_.c_str());
+    // angular_body + angular_cov_body stay zero-initialized.
+    have_angular = true;  // state still "received" — zeros are the honest answer.
+  } else if (!same_frame) {
     try {
       auto tf = tf_buffer_->lookupTransform(
         base_frame_, orientation.header.frame_id, tf2::TimePointZero);
@@ -214,7 +224,7 @@ void MRUTransform::updateOrientation(const OrientationSensor::ValueType &orienta
       have_angular = true;  // state still "received" — zeros are the honest answer.
     }
   } else {
-    // Same-frame path (frame_id is base_frame_ or empty) — copy directly.
+    // Same-frame path (frame_id explicitly == base_frame_) — copy directly.
     angular_body = orientation.angular_velocity;
     for (int i = 0; i < 9; ++i) {
       angular_cov_body[i] = orientation.angular_velocity_covariance[i];

--- a/mru_transform/src/mru_transform.cpp
+++ b/mru_transform/src/mru_transform.cpp
@@ -97,7 +97,15 @@ void MRUTransform::updatePosition(PositionSensor::ValueType position)
   map_to_north_up_base_link.transform.translation.z = position_map.z-sensor_offset.z();
   transforms.push_back(map_to_north_up_base_link);
   broadcaster_->sendTransform(transforms);
-  odom_.pose.pose.position = position_map;
+
+  // Record latest position under state_mu_ for updateVelocity to compose
+  // into the published Odometry.  Keeps the three callbacks free of a
+  // shared nav_msgs::Odometry member and safe under a MultiThreadedExecutor.
+  {
+    std::lock_guard<std::mutex> lock(state_mu_);
+    latest_position_map_ = position_map;
+    have_position_ = true;
+  }
 }
 
 void MRUTransform::updateOrientation(const OrientationSensor::ValueType &orientation)
@@ -131,8 +139,10 @@ void MRUTransform::updateOrientation(const OrientationSensor::ValueType &orienta
   transforms.push_back(north_up_base_link_to_base_link);
   broadcaster_->sendTransform(transforms);
 
-  odom_.pose.pose.orientation = orientation.orientation;
-
+  // Compute angular velocity + covariance in base_frame_ locally, then
+  // commit to state under state_mu_.  Keeps this callback free of the
+  // shared Odometry mutation the pre-refactor code had.
+  //
   // REP-105: angular velocity must be expressed in child_frame_id (body).
   // IMU-sourced gyro is in orientation.header.frame_id (typically the IMU's
   // physical frame).  Rotate into body frame using the static sensor-to-base
@@ -145,10 +155,14 @@ void MRUTransform::updateOrientation(const OrientationSensor::ValueType &orienta
   // cannot express the gyro in body frame: "no angular info available"
   // rather than "angular info in an unknown frame".  The WARN_THROTTLE
   // tells the operator to set up the missing static TF.
+  geometry_msgs::msg::Vector3 angular_body;
+  std::array<double, 9> angular_cov_body{};
+
   const bool same_frame =
     orientation.header.frame_id.empty() ||
     orientation.header.frame_id == base_frame_;
 
+  bool have_angular = false;
   if (!same_frame) {
     try {
       auto tf = tf_buffer_->lookupTransform(
@@ -161,54 +175,59 @@ void MRUTransform::updateOrientation(const OrientationSensor::ValueType &orienta
                         orientation.angular_velocity.y,
                         orientation.angular_velocity.z);
       tf2::Vector3 w_out = R * w_in;
-      odom_.twist.twist.angular.x = w_out.x();
-      odom_.twist.twist.angular.y = w_out.y();
-      odom_.twist.twist.angular.z = w_out.z();
+      angular_body.x = w_out.x();
+      angular_body.y = w_out.y();
+      angular_body.z = w_out.z();
 
-      // Rotate angular-covariance sub-block.  The source (sensor_msgs/Imu)
-      // stores angular_velocity_covariance as a flat 9-array; promote into a
-      // 36-array with the angular block populated, rotate, then copy back.
-      // (Only the 3x3 angular-diagonal sub-block is rotated — see
-      //  twist_rotation_utils.hpp for the helper's scope.)
+      // Rotate angular-covariance sub-block.  (Only the 3x3 angular-diagonal
+      // sub-block is rotated — see twist_rotation_utils.hpp for the helper's
+      // scope.)  We use a 36-array scratch because the helper operates on
+      // 6x6 twist covariance layouts; copy the rotated 3x3 back out.
       std::array<double, 36> cov_in_6x6{};
+      std::array<double, 36> cov_out_6x6{};
       for (int i = 0; i < 3; ++i) {
         for (int j = 0; j < 3; ++j) {
           cov_in_6x6[(i + 3) * 6 + (j + 3)] =
             orientation.angular_velocity_covariance[i * 3 + j];
         }
       }
-      rotate_covariance_block_3x3(cov_in_6x6, R, 3, odom_.twist.covariance);
-      return;
+      rotate_covariance_block_3x3(cov_in_6x6, R, 3, cov_out_6x6);
+      for (int i = 0; i < 3; ++i) {
+        for (int j = 0; j < 3; ++j) {
+          angular_cov_body[i * 3 + j] =
+            cov_out_6x6[(i + 3) * 6 + (j + 3)];
+        }
+      }
+      have_angular = true;
     } catch (const tf2::TransformException &e) {
       RCLCPP_WARN_THROTTLE(node_->get_logger(), *node_->get_clock(), 5000,
         "orientation: TF '%s' -> '%s' lookup failed: %s (publishing zero angular — set up a static TF to eliminate this warning)",
         orientation.header.frame_id.c_str(), base_frame_.c_str(), e.what());
-      odom_.twist.twist.angular = geometry_msgs::msg::Vector3();
-      for (int i = 0; i < 3; ++i) {
-        for (int j = 0; j < 3; ++j) {
-          odom_.twist.covariance[(i + 3) * 6 + (j + 3)] = 0.0;
-        }
-      }
-      return;
+      // angular_body + angular_cov_body stay zero-initialized.
+      have_angular = true;  // state still "received" — zeros are the honest answer.
     }
+  } else {
+    // Same-frame path (frame_id is base_frame_ or empty) — copy directly.
+    angular_body = orientation.angular_velocity;
+    for (int i = 0; i < 9; ++i) {
+      angular_cov_body[i] = orientation.angular_velocity_covariance[i];
+    }
+    have_angular = true;
   }
 
-  // Same-frame path (frame_id is base_frame_ or empty) — copy angular directly.
-  odom_.twist.twist.angular = orientation.angular_velocity;
-  for (int i = 0; i < 3; ++i) {
-    for (int j = 0; j < 3; ++j) {
-      odom_.twist.covariance[(i + 3) * 6 + (j + 3)] =
-        orientation.angular_velocity_covariance[i * 3 + j];
+  {
+    std::lock_guard<std::mutex> lock(state_mu_);
+    latest_orientation_ = orientation.orientation;
+    if (have_angular) {
+      latest_angular_body_ = angular_body;
+      latest_angular_cov_body_ = angular_cov_body;
     }
+    have_orientation_ = true;
   }
 }
 
 void MRUTransform::updateVelocity(const VelocitySensor::ValueType &velocity)
 {
-  odom_.header.frame_id = odom_frame_;
-  odom_.header.stamp = velocity.header.stamp;
-  odom_.child_frame_id = base_frame_;
-
   // REP-105: odom.twist must be expressed in child_frame_id (body).  Incoming
   // velocity is in velocity.header.frame_id — typically a world frame (map,
   // posmv_frame, mru_frame).  Rotate linear velocity + covariance into body
@@ -230,22 +249,51 @@ void MRUTransform::updateVelocity(const VelocitySensor::ValueType &velocity)
   tf2::fromMsg(tf.transform.rotation, q);
   tf2::Matrix3x3 R(q);
 
-  // Rotate linear velocity
+  // Rotate linear velocity into base_frame_.
   tf2::Vector3 v_in(velocity.twist.twist.linear.x,
                     velocity.twist.twist.linear.y,
                     velocity.twist.twist.linear.z);
   tf2::Vector3 v_out = R * v_in;
-  odom_.twist.twist.linear.x = v_out.x();
-  odom_.twist.twist.linear.y = v_out.y();
-  odom_.twist.twist.linear.z = v_out.z();
+  geometry_msgs::msg::Vector3 linear_body;
+  linear_body.x = v_out.x();
+  linear_body.y = v_out.y();
+  linear_body.z = v_out.z();
+
+  // Compose the full Odometry message locally from (a) this velocity's
+  // rotated linear + covariance and (b) a snapshot of the latest position /
+  // orientation / angular state contributed by the other two callbacks under
+  // state_mu_.  The snapshot is taken under the lock and then released — the
+  // publish runs outside the critical section.
+  nav_msgs::msg::Odometry odom;
+  odom.header.frame_id = odom_frame_;
+  odom.header.stamp = velocity.header.stamp;
+  odom.child_frame_id = base_frame_;
+  odom.twist.twist.linear = linear_body;
 
   // Rotate linear-covariance sub-block (upper-left 3x3).  Cross-covariance
   // blocks between linear and angular are not touched — see the scope note
   // in twist_rotation_utils.hpp.
   rotate_covariance_block_3x3(velocity.twist.covariance, R, 0,
-                              odom_.twist.covariance);
+                              odom.twist.covariance);
 
-  odom_pub_->publish(odom_);
+  {
+    std::lock_guard<std::mutex> lock(state_mu_);
+    if (have_position_) {
+      odom.pose.pose.position = latest_position_map_;
+    }
+    if (have_orientation_) {
+      odom.pose.pose.orientation = latest_orientation_;
+      odom.twist.twist.angular = latest_angular_body_;
+      for (int i = 0; i < 3; ++i) {
+        for (int j = 0; j < 3; ++j) {
+          odom.twist.covariance[(i + 3) * 6 + (j + 3)] =
+            latest_angular_cov_body_[i * 3 + j];
+        }
+      }
+    }
+  }
+
+  odom_pub_->publish(odom);
 }
 
 void MRUTransform::resetMapFrameService(const std_srvs::srv::Trigger::Request::SharedPtr request,

--- a/mru_transform/src/orientation_sensor.cpp
+++ b/mru_transform/src/orientation_sensor.cpp
@@ -43,10 +43,17 @@ bool OrientationSensor::subscribe(const std::vector<std::string>& topic_types)
 
 void OrientationSensor::imuCallback(const sensor_msgs::msg::Imu::SharedPtr msg)
 {
+  // Copy the full Imu payload, covariances included.  Without the covariance
+  // copies below, MRUTransform::updateOrientation would always rotate a
+  // default-zero angular_velocity_covariance and the published odom twist
+  // covariance would be meaningless regardless of what the IMU reports.
   latest_value_.header = msg->header;
   latest_value_.orientation = msg->orientation;
+  latest_value_.orientation_covariance = msg->orientation_covariance;
   latest_value_.angular_velocity = msg->angular_velocity;
+  latest_value_.angular_velocity_covariance = msg->angular_velocity_covariance;
   latest_value_.linear_acceleration = msg->linear_acceleration;
+  latest_value_.linear_acceleration_covariance = msg->linear_acceleration_covariance;
   call_callbacks_(latest_value_);
 }
 

--- a/mru_transform/src/orientation_sensor.cpp
+++ b/mru_transform/src/orientation_sensor.cpp
@@ -52,15 +52,31 @@ void OrientationSensor::imuCallback(const sensor_msgs::msg::Imu::SharedPtr msg)
 
 void OrientationSensor::quaternionCallback(const geometry_msgs::msg::QuaternionStamped::SharedPtr msg)
 {
+  RCLCPP_WARN_ONCE(logger_,
+    "Orientation source '%s' is a QuaternionStamped — angular_velocity is "
+    "not available from this source type and will be published as zero. "
+    "Use a sensor_msgs/Imu source if angular velocity is needed downstream.",
+    topic_.c_str());
   latest_value_.header = msg->header;
   latest_value_.orientation = msg->quaternion;
+  // Explicitly clear angular_velocity to avoid publishing stale data from a
+  // prior IMU stream.
+  latest_value_.angular_velocity = geometry_msgs::msg::Vector3();
+  for (auto &c : latest_value_.angular_velocity_covariance) c = 0.0;
   call_callbacks_(latest_value_);
 }
 
 void OrientationSensor::geoPoseCallback(const geographic_msgs::msg::GeoPoseStamped::SharedPtr msg)
 {
+  RCLCPP_WARN_ONCE(logger_,
+    "Orientation source '%s' is a GeoPoseStamped — angular_velocity is "
+    "not available from this source type and will be published as zero. "
+    "Use a sensor_msgs/Imu source if angular velocity is needed downstream.",
+    topic_.c_str());
   latest_value_.header = msg->header;
   latest_value_.orientation = msg->pose.orientation;
+  latest_value_.angular_velocity = geometry_msgs::msg::Vector3();
+  for (auto &c : latest_value_.angular_velocity_covariance) c = 0.0;
   call_callbacks_(latest_value_);
 }
 

--- a/mru_transform/src/velocity_sensor.cpp
+++ b/mru_transform/src/velocity_sensor.cpp
@@ -6,7 +6,7 @@ namespace mru_transform
 {
 
 template <>
-const std::string SensorBase<geometry_msgs::msg::TwistStamped>::sensor_type("velocity");
+const std::string SensorBase<geometry_msgs::msg::TwistWithCovarianceStamped>::sensor_type("velocity");
 
 VelocitySensor::VelocitySensor(NodeInterfaces node, std::string name, CallbackType callback)
     :BaseType(node, name, callback)
@@ -37,14 +37,18 @@ bool VelocitySensor::subscribe(const std::vector<std::string> &topic_types)
 
 void VelocitySensor::twistWithCovarianceCallback(const geometry_msgs::msg::TwistWithCovarianceStamped::SharedPtr msg)
 {
-  latest_value_.header = msg->header;
-  latest_value_.twist = msg->twist.twist;
+  latest_value_ = *msg;
   call_callbacks_(latest_value_);
 }
 
 void VelocitySensor::twistCallback(const geometry_msgs::msg::TwistStamped::SharedPtr msg)
 {
-  latest_value_ = *msg;
+  latest_value_.header = msg->header;
+  latest_value_.twist.twist = msg->twist;
+  // Covariance is unknown for plain TwistStamped — leave at default-constructed zeros.
+  for (auto &c : latest_value_.twist.covariance) {
+    c = 0.0;
+  }
   call_callbacks_(latest_value_);
 }
 

--- a/mru_transform/test/test_twist_rotation.cpp
+++ b/mru_transform/test/test_twist_rotation.cpp
@@ -1,0 +1,235 @@
+// Tests for REP-105 twist rotation math in mru_transform.
+//
+// The production rotation in MRUTransform::updateVelocity /
+// updateOrientation goes:
+//   Sigma_body = R * Sigma_world * R^T
+//   v_body     = R * v_world
+// where R is the rotation extracted from a TF lookup
+// (base_frame ← header.frame_id).  These tests exercise the covariance
+// rotation helper and the vector rotation both for correctness on
+// synthetic inputs with known expected outputs and for the structural
+// invariants that any rotation must preserve (trace, determinant,
+// symmetry, magnitude).
+
+#include <array>
+#include <cmath>
+
+#include <gtest/gtest.h>
+#include <tf2/LinearMath/Matrix3x3.h>
+#include <tf2/LinearMath/Quaternion.h>
+#include <tf2/LinearMath/Vector3.h>
+
+#include "mru_transform/twist_rotation_utils.hpp"
+
+namespace
+{
+
+constexpr double kEpsilon = 1e-9;
+
+tf2::Matrix3x3 yawRotation(double yaw_rad)
+{
+  tf2::Quaternion q;
+  q.setRPY(0.0, 0.0, yaw_rad);
+  return tf2::Matrix3x3(q);
+}
+
+// Build a 6x6 covariance array with the 3x3 block at (offset, offset)
+// populated from a flat 9-array row-major.  Other entries zero.
+std::array<double, 36> makeBlockCovariance(
+  const std::array<double, 9> &block, int offset)
+{
+  std::array<double, 36> cov{};
+  for (int i = 0; i < 3; ++i) {
+    for (int j = 0; j < 3; ++j) {
+      cov[(offset + i) * 6 + (offset + j)] = block[i * 3 + j];
+    }
+  }
+  return cov;
+}
+
+std::array<double, 9> extractBlock(
+  const std::array<double, 36> &cov, int offset)
+{
+  std::array<double, 9> block{};
+  for (int i = 0; i < 3; ++i) {
+    for (int j = 0; j < 3; ++j) {
+      block[i * 3 + j] = cov[(offset + i) * 6 + (offset + j)];
+    }
+  }
+  return block;
+}
+
+}  // namespace
+
+// -------------------------------------------------------------------------
+// Vector rotation sanity (uses bare tf2::Matrix3x3 so the test doubles as
+// documentation of what MRUTransform expects).
+// -------------------------------------------------------------------------
+
+TEST(VectorRotation, IdentityIsNoOp)
+{
+  tf2::Matrix3x3 I;
+  I.setIdentity();
+  tf2::Vector3 v(1.2, -3.4, 5.6);
+  tf2::Vector3 r = I * v;
+  EXPECT_NEAR(r.x(), 1.2, kEpsilon);
+  EXPECT_NEAR(r.y(), -3.4, kEpsilon);
+  EXPECT_NEAR(r.z(), 5.6, kEpsilon);
+}
+
+TEST(VectorRotation, Yaw90DegRotatesEastToNorth)
+{
+  // ENU convention: yaw=0 points East along body-X, yaw=+90deg rotates body-X
+  // to North.  Equivalently, a world vector pointing East expressed in a body
+  // that has been yawed +90deg should be -Y in body (the body sees it as
+  // starboard direction).
+  //
+  // Here we rotate the vector itself: R(yaw=+90deg) applied to East (+x) gives
+  // +North (+y).
+  auto R = yawRotation(M_PI / 2);
+  tf2::Vector3 east(1.0, 0.0, 0.0);
+  tf2::Vector3 north = R * east;
+  EXPECT_NEAR(north.x(), 0.0, 1e-12);
+  EXPECT_NEAR(north.y(), 1.0, 1e-12);
+  EXPECT_NEAR(north.z(), 0.0, 1e-12);
+}
+
+TEST(VectorRotation, PreservesMagnitude)
+{
+  auto R = yawRotation(1.23);  // arbitrary angle
+  tf2::Vector3 v(0.7, -1.9, 2.4);
+  tf2::Vector3 r = R * v;
+  EXPECT_NEAR(v.length(), r.length(), 1e-12);
+}
+
+// -------------------------------------------------------------------------
+// rotate_covariance_block_3x3 — helper from twist_rotation_utils.hpp
+// -------------------------------------------------------------------------
+
+TEST(CovarianceRotation, IdentityIsNoOp)
+{
+  const std::array<double, 9> block{
+    0.04, 0.00, 0.00,
+    0.00, 0.02, 0.00,
+    0.00, 0.00, 0.01};
+  auto cov_in = makeBlockCovariance(block, 0);
+  std::array<double, 36> cov_out{};
+  tf2::Matrix3x3 I; I.setIdentity();
+  mru_transform::rotate_covariance_block_3x3(cov_in, I, 0, cov_out);
+  auto out_block = extractBlock(cov_out, 0);
+  for (size_t i = 0; i < 9; ++i) {
+    EXPECT_NEAR(out_block[i], block[i], kEpsilon) << "entry " << i;
+  }
+}
+
+TEST(CovarianceRotation, Yaw90SwapsDiagonalXY)
+{
+  // Diagonal covariance: sigma_xx=4, sigma_yy=1, sigma_zz=9 (units m^2/s^2)
+  const std::array<double, 9> block{
+    4.0, 0.0, 0.0,
+    0.0, 1.0, 0.0,
+    0.0, 0.0, 9.0};
+  auto cov_in = makeBlockCovariance(block, 0);
+  std::array<double, 36> cov_out{};
+  auto R = yawRotation(M_PI / 2);
+  mru_transform::rotate_covariance_block_3x3(cov_in, R, 0, cov_out);
+  auto out_block = extractBlock(cov_out, 0);
+  // 90-degree yaw rotates the covariance ellipse by 90deg: xx <-> yy.
+  EXPECT_NEAR(out_block[0 * 3 + 0], 1.0, 1e-12);  // new xx was old yy
+  EXPECT_NEAR(out_block[1 * 3 + 1], 4.0, 1e-12);  // new yy was old xx
+  EXPECT_NEAR(out_block[2 * 3 + 2], 9.0, 1e-12);  // zz untouched
+  // Off-diagonals must remain zero.
+  EXPECT_NEAR(out_block[0 * 3 + 1], 0.0, 1e-12);
+  EXPECT_NEAR(out_block[1 * 3 + 0], 0.0, 1e-12);
+}
+
+TEST(CovarianceRotation, PreservesTrace)
+{
+  // Trace is invariant under similarity transforms A^T Sigma A = A Sigma A^T
+  // when A is orthogonal (which rotation matrices are).
+  const std::array<double, 9> block{
+    0.50, 0.15, 0.02,
+    0.15, 0.40, 0.03,
+    0.02, 0.03, 0.30};
+  auto cov_in = makeBlockCovariance(block, 0);
+  std::array<double, 36> cov_out{};
+  auto R = yawRotation(0.317);
+  mru_transform::rotate_covariance_block_3x3(cov_in, R, 0, cov_out);
+  double trace_in = block[0] + block[4] + block[8];
+  auto out_block = extractBlock(cov_out, 0);
+  double trace_out = out_block[0] + out_block[4] + out_block[8];
+  EXPECT_NEAR(trace_in, trace_out, 1e-12);
+}
+
+TEST(CovarianceRotation, PreservesSymmetry)
+{
+  // A symmetric input rotated by an orthogonal matrix must remain symmetric.
+  const std::array<double, 9> block{
+    0.25, 0.10, -0.05,
+    0.10, 0.60,  0.07,
+    -0.05, 0.07, 0.15};
+  auto cov_in = makeBlockCovariance(block, 0);
+  std::array<double, 36> cov_out{};
+  tf2::Quaternion q;
+  q.setRPY(0.2, -0.4, 0.6);
+  tf2::Matrix3x3 R(q);
+  mru_transform::rotate_covariance_block_3x3(cov_in, R, 0, cov_out);
+  auto out_block = extractBlock(cov_out, 0);
+  EXPECT_NEAR(out_block[0 * 3 + 1], out_block[1 * 3 + 0], 1e-12);
+  EXPECT_NEAR(out_block[0 * 3 + 2], out_block[2 * 3 + 0], 1e-12);
+  EXPECT_NEAR(out_block[1 * 3 + 2], out_block[2 * 3 + 1], 1e-12);
+}
+
+TEST(CovarianceRotation, AngularBlockOffset3)
+{
+  // Same math, but the block lives at offset 3 (lower-right 3x3 of the 6x6
+  // twist.covariance) — verifies the offset logic is correct.
+  const std::array<double, 9> block{
+    4.0, 0.0, 0.0,
+    0.0, 1.0, 0.0,
+    0.0, 0.0, 9.0};
+  auto cov_in = makeBlockCovariance(block, 3);
+  std::array<double, 36> cov_out{};
+  auto R = yawRotation(M_PI / 2);
+  mru_transform::rotate_covariance_block_3x3(cov_in, R, 3, cov_out);
+  // Linear block (0..2, 0..2) must be untouched.
+  for (int i = 0; i < 3; ++i) {
+    for (int j = 0; j < 3; ++j) {
+      EXPECT_NEAR(cov_out[i * 6 + j], 0.0, kEpsilon)
+        << "linear block leaked at (" << i << "," << j << ")";
+    }
+  }
+  // Angular block: xx<->yy swap as in the yaw-90 case.
+  auto out_block = extractBlock(cov_out, 3);
+  EXPECT_NEAR(out_block[0 * 3 + 0], 1.0, 1e-12);
+  EXPECT_NEAR(out_block[1 * 3 + 1], 4.0, 1e-12);
+  EXPECT_NEAR(out_block[2 * 3 + 2], 9.0, 1e-12);
+}
+
+TEST(CovarianceRotation, HandComputedRotationMatchesClosedForm)
+{
+  // Concrete scenario: 45-degree yaw on a purely forward-variance input
+  //   Sigma_in = diag(1, 0, 0)
+  //   R = Rz(pi/4) = [[c, -s, 0], [s, c, 0], [0, 0, 1]] with c=s=sqrt(2)/2
+  //   Sigma_out = R Sigma_in R^T = 0.5 * [[1, 1, 0], [1, 1, 0], [0, 0, 0]]
+  const std::array<double, 9> block{
+    1.0, 0.0, 0.0,
+    0.0, 0.0, 0.0,
+    0.0, 0.0, 0.0};
+  auto cov_in = makeBlockCovariance(block, 0);
+  std::array<double, 36> cov_out{};
+  auto R = yawRotation(M_PI / 4);
+  mru_transform::rotate_covariance_block_3x3(cov_in, R, 0, cov_out);
+  auto out_block = extractBlock(cov_out, 0);
+  EXPECT_NEAR(out_block[0 * 3 + 0], 0.5, 1e-12);
+  EXPECT_NEAR(out_block[0 * 3 + 1], 0.5, 1e-12);
+  EXPECT_NEAR(out_block[1 * 3 + 0], 0.5, 1e-12);
+  EXPECT_NEAR(out_block[1 * 3 + 1], 0.5, 1e-12);
+  EXPECT_NEAR(out_block[2 * 3 + 2], 0.0, 1e-12);
+}
+
+int main(int argc, char ** argv)
+{
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/mru_transform/test/test_twist_rotation.cpp
+++ b/mru_transform/test/test_twist_rotation.cpp
@@ -1,15 +1,17 @@
-// Tests for REP-105 twist rotation math in mru_transform.
+// Tests for REP-105 twist covariance rotation in mru_transform.
 //
 // The production rotation in MRUTransform::updateVelocity /
 // updateOrientation goes:
 //   Sigma_body = R * Sigma_world * R^T
-//   v_body     = R * v_world
 // where R is the rotation extracted from a TF lookup
 // (base_frame ← header.frame_id).  These tests exercise the covariance
-// rotation helper and the vector rotation both for correctness on
-// synthetic inputs with known expected outputs and for the structural
-// invariants that any rotation must preserve (trace, determinant,
-// symmetry, magnitude).
+// rotation helper for correctness on synthetic inputs with known expected
+// outputs and for the structural invariants any orthogonal similarity
+// transform must preserve (trace, symmetry).
+//
+// Vector rotation itself (v_body = R * v_world) is exercised directly by
+// tf2::Matrix3x3::operator*(tf2::Vector3) — no mru_transform code of its
+// own — so it's not repeated here.
 
 #include <array>
 #include <cmath>
@@ -17,7 +19,6 @@
 #include <gtest/gtest.h>
 #include <tf2/LinearMath/Matrix3x3.h>
 #include <tf2/LinearMath/Quaternion.h>
-#include <tf2/LinearMath/Vector3.h>
 
 #include "mru_transform/twist_rotation_utils.hpp"
 
@@ -60,47 +61,6 @@ std::array<double, 9> extractBlock(
 }
 
 }  // namespace
-
-// -------------------------------------------------------------------------
-// Vector rotation sanity (uses bare tf2::Matrix3x3 so the test doubles as
-// documentation of what MRUTransform expects).
-// -------------------------------------------------------------------------
-
-TEST(VectorRotation, IdentityIsNoOp)
-{
-  tf2::Matrix3x3 I;
-  I.setIdentity();
-  tf2::Vector3 v(1.2, -3.4, 5.6);
-  tf2::Vector3 r = I * v;
-  EXPECT_NEAR(r.x(), 1.2, kEpsilon);
-  EXPECT_NEAR(r.y(), -3.4, kEpsilon);
-  EXPECT_NEAR(r.z(), 5.6, kEpsilon);
-}
-
-TEST(VectorRotation, Yaw90DegRotatesEastToNorth)
-{
-  // ENU convention: yaw=0 points East along body-X, yaw=+90deg rotates body-X
-  // to North.  Equivalently, a world vector pointing East expressed in a body
-  // that has been yawed +90deg should be -Y in body (the body sees it as
-  // starboard direction).
-  //
-  // Here we rotate the vector itself: R(yaw=+90deg) applied to East (+x) gives
-  // +North (+y).
-  auto R = yawRotation(M_PI / 2);
-  tf2::Vector3 east(1.0, 0.0, 0.0);
-  tf2::Vector3 north = R * east;
-  EXPECT_NEAR(north.x(), 0.0, 1e-12);
-  EXPECT_NEAR(north.y(), 1.0, 1e-12);
-  EXPECT_NEAR(north.z(), 0.0, 1e-12);
-}
-
-TEST(VectorRotation, PreservesMagnitude)
-{
-  auto R = yawRotation(1.23);  // arbitrary angle
-  tf2::Vector3 v(0.7, -1.9, 2.4);
-  tf2::Vector3 r = R * v;
-  EXPECT_NEAR(v.length(), r.length(), 1e-12);
-}
 
 // -------------------------------------------------------------------------
 // rotate_covariance_block_3x3 — helper from twist_rotation_utils.hpp

--- a/mru_transform/test/test_twist_rotation.cpp
+++ b/mru_transform/test/test_twist_rotation.cpp
@@ -105,8 +105,8 @@ TEST(CovarianceRotation, Yaw90SwapsDiagonalXY)
 
 TEST(CovarianceRotation, PreservesTrace)
 {
-  // Trace is invariant under similarity transforms A^T Sigma A = A Sigma A^T
-  // when A is orthogonal (which rotation matrices are).
+  // Covariance rotation Sigma' = R Sigma R^T with orthogonal R (rotation
+  // matrices are orthogonal) preserves trace: tr(Sigma') = tr(Sigma).
   const std::array<double, 9> block{
     0.50, 0.15, 0.02,
     0.15, 0.40, 0.03,


### PR DESCRIPTION
Closes #18

## Summary

Rotate `odom.twist.linear`, `odom.twist.angular`, and the diagonal
blocks of `twist.covariance` into `child_frame_id` (body) per
REP-105.  Previously all three were published in the world frame of
the incoming sensor messages, silently wrong by the vessel's heading.

Field evidence that drove this (from the 2026-04-21 BizzyBoat session):
correlation between `/bizzy/odom.twist.linear` and
`/bizzy/mavros/.../gps_vel.twist.linear` was 1.0000 with median diff
0.0 mm/s — literally the same ENU signal.  Simulation helm PIDs
(`asv_helm`, `ben_gazebo/gazebo_helm`) read `odom.twist.linear.x` as
body-forward feedback; any heading ≠ due east made their throttle
loops misbehave.

## Behavior changes

### REP-105 compliance

- **`VelocitySensor::ValueType`** now `TwistWithCovarianceStamped`
  (was `TwistStamped`).  Covariance is preserved end-to-end; the
  plain-`TwistStamped` subscription path zero-fills the covariance
  block.
- **`MRUTransform::updateVelocity`** rotates linear velocity + linear
  covariance block via a TF lookup keyed on `velocity.header.frame_id`
  at `velocity.header.stamp`.  **Drops with `RCLCPP_WARN_THROTTLE(5s)`
  on TF failure** (empty/unresolvable frame).
- **`MRUTransform::updateOrientation`** rotates angular velocity +
  angular covariance block via a static TF lookup keyed on
  `imu.header.frame_id` (uses `TimePointZero` because sensor → base
  TFs are static).  **On TF failure publishes zero angular velocity
  and zero angular covariance** — the honest representation when we
  can't rotate into body frame, rather than leaving stale body-frame
  values or silently falling through with sensor-frame values.  Pose
  TFs continue to broadcast.
- **`OrientationSensor::imuCallback`** now copies all three IMU
  covariance arrays into `latest_value_` — previously
  `angular_velocity_covariance` was dropped, which would have
  defeated the rotation work.
- **`OrientationSensor::{quaternion,geoPose}Callback`** now
  `RCLCPP_WARN_ONCE` that angular velocity is unavailable from those
  source types, and explicitly zero `latest_value_.angular_velocity`
  so the field is predictable rather than stale.
- **`include/mru_transform/twist_rotation_utils.hpp`** new — contains
  the `rotate_covariance_block_3x3` helper (`Σ_out = R Σ_in Rᵀ`) used
  by both update paths and by the unit tests.  Rotates diagonal 3×3
  blocks only; callers must initialize/clear other blocks of the
  output as needed.

### Thread-safety refactor

The previous shared `odom_` member mutated from three callbacks was
safe under a single-threaded executor but one configuration change
away from UB under a `MultiThreadedExecutor`.

- `odom_` removed as a member.  Replaced with a small mutex-guarded
  state snapshot (`latest_position_map_`, `latest_orientation_`,
  `latest_angular_body_`, `latest_angular_cov_body_` + `have_*` flags).
- Each callback computes its contribution outside the lock and
  commits under `state_mu_`.  `updateVelocity` briefly locks to copy
  the snapshot into a *local* `nav_msgs::msg::Odometry`, releases,
  and publishes outside the critical section.
- Behavior on the boat (single-threaded executor) is unchanged.

## Tests

`test_twist_rotation.cpp` — 6 gtest cases covering the covariance
rotation helper:

- Identity rotation no-op
- 90° yaw swapping diagonal XY covariance entries
- Trace preservation under orthogonal rotation
- Symmetry preservation under orthogonal rotation
- Offset-3 angular block placement (no leak into linear block)
- Hand-computed 45° yaw closed form:
  `diag(1, 0, 0)` → `0.5 · [[1,1,0],[1,1,0],[0,0,0]]`

```
Summary: 7 tests, 0 errors, 0 failures, 0 skipped
```
(6 gtest cases + 1 `ament_lint_auto` fixture.)

End-to-end coverage of the TF-driven callback paths
(`updateVelocity` / `updateOrientation` with a populated
`tf2_ros::Buffer`) is deferred to
[rolker/mru_transform#20](https://github.com/rolker/mru_transform/issues/20).

## Manual bag regression (suggested before merging)

Replay a BizzyBoat bag and assert on `/bizzy/odom`:

1. `|odom.twist.linear|` magnitude matches `|gps_vel.twist.linear|`
   (frame-invariant — must hold both pre- and post-fix)
2. Rotating `odom.twist.linear` by `+yaw_enu` (from IMU) matches
   `gps_vel.twist.linear` component-wise.  Pre-fix this residual has
   a heading-dependent structure; post-fix it should be zero.

## Deployment note for `rolker/posmv` users

`posmv` publishes with `header.frame_id = posmv_frame` (user
configured).  After this fix a static TF `posmv_frame → map` (or
whichever world frame is in the TF tree) is required, or velocity
messages will drop with a throttled warning.  This is correct REP-105
behavior — not a regression — but it is a new operational requirement
for existing posmv users who relied on the pre-fix pass-through.

## Commit log

1. Plan + review-driven updates
2. `VelocitySensor` value type → `TwistWithCovarianceStamped`
3. Rotate linear + angular + covariance (REP-105 core fix)
4. `WARN_ONCE` on non-IMU orientation sources
5. gtest coverage for rotation math
6. Review-action 1: zero angular on orientation TF failure
7. Review-action 2: document cross-covariance scope of helper
8. Review-action 4: plan filename correction
9. Review-action 5: drop vector-rotation tests (tf2 math, not ours)
10. Eliminate shared-odom_ data race (thread safety)
11. Triage fix: copy IMU covariance fields through OrientationSensor
12. Triage fix: correct helper + updateVelocity comments

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.7 (1M context)`
