### PR TITLE
Datum support off-VDatum: polygon-keyed datum config (always-on) + lake_datum override

### DIFF
--- a/.agent/work-plans/issue-25/plan.md
+++ b/.agent/work-plans/issue-25/plan.md
@@ -1,0 +1,120 @@
+# Plan: Datum support off-VDatum: polygon-keyed datum config (always-on) + lake_datum override
+
+## Issue
+
+https://github.com/rolker/mru_transform/issues/25
+
+## Context
+
+`chart_datum_node` (a `LifecycleNode`) publishes `map → chart_datum`/`mhhw` TF
+from NOAA VDatum `.gtx` grids via PROJ. Two gaps block "works anywhere":
+
+1. `on_configure` **hard-fails** (`CallbackReturn::FAILURE`) when `vdatum_grid_dir`
+   is empty — so the node won't even configure with no grids.
+2. `recalc_callback` only sets `has_valid_mllw_` on a VDatum hit; `publish_callback`
+   gates publishing on that flag. Off-VDatum (e.g. Massabesic, inside the grid dir
+   but outside coverage) **no `chart_datum` frame is published at all**.
+
+We add a resolution chain — VDatum → polygon config → `lake_datum` param →
+ellipsoid default — so a datum is always resolvable, with the source tracked and
+logged. The review comment (issue #25) flagged: keep deployment-specific polygon
+data out of this generic package, tag every datum with its provenance, and verify
+downstream consumers tolerate an always-on frame.
+
+## Approach
+
+1. **Extract a pure, ROS-free resolution core** — new header
+   `include/mru_transform/datum_config.hpp` (+ `src/datum_config.cpp`):
+   `DatumEntry {name, ring<lat,lon>, chart_datum_z, optional mhhw_z}`,
+   `point_in_ring()` (ray-cast), `load_datum_config(path)` (yaml-cpp parse),
+   `resolve(lat, lon, entries) -> optional<DatumEntry>`. Pure logic so it unit-tests
+   without rclcpp. Define a `DatumSource` enum {VDATUM, POLYGON_CONFIG, PARAM,
+   ELLIPSOID_DEFAULT}.
+2. **Make VDatum optional in `on_configure`** — if `vdatum_grid_dir` is empty or no
+   MLLW grids found, skip PROJ setup and log once (INFO), do **not** FAILURE. Keep
+   `geoid_grid` required only when VDatum is used. PROJ pointers stay null → guarded.
+3. **Add parameters** — `datum_config_path` (string, ""), `datum_config_override`
+   (bool, false → config is a VDatum *fallback*; true → consult config *first*),
+   `lake_datum` (double, NaN sentinel = unset; fixed datum-below-ellipsoid z),
+   `lake_datum_mhhw` (double, NaN = unset). Declare/get in `on_configure`; load the
+   config file there if the path is set.
+4. **Rewrite `recalc_callback` as the resolution chain** producing
+   `(chart_datum_z_, optional mhhw_z_, DatumSource, name)`:
+   override-first config (if flag) → VDatum → fallback config → `lake_datum` param →
+   ellipsoid default (z=0). Always ends with a valid datum. Set `has_valid_mllw_` =
+   true in all branches; keep `has_valid_mhhw_` only when a source supplies MHHW.
+   Log the resolved source + name with `RCLCPP_INFO` on change (not just _ONCE, since
+   the source can change as the boat moves), and `RCLCPP_WARN` once when falling to
+   the ellipsoid default.
+5. **Publish provenance** — add a latched `std_msgs::msg::String` publisher
+   `datum_source` (values like `"vdatum"`, `"polygon:Massabesic"`, `"param"`,
+   `"ellipsoid_default"`) so consumers/operators can distinguish a surveyed datum
+   from the safe fallback. Publish in `publish_callback` alongside the TF.
+6. **Ship a generic example config, not Massabesic data** —
+   `config/datum_polygons.example.yaml` with a documented schema and one *synthetic*
+   entry. The real Lake Massabesic polygon goes in the platform/site overlay
+   (echoboats/bizzy) as a follow-up, passed via `datum_config_path`. Satisfies
+   acceptance item 6 in the right repo.
+7. **Tests** — `test/test_datum_config.cpp` (gtest): point-in-ring (inside, outside,
+   on-boundary, ring that wraps longitude), config parse (valid/missing-file/malformed),
+   and `resolve()` precedence (override-first vs fallback; param override; ellipsoid
+   default when nothing matches). Register in `CMakeLists.txt`.
+8. **Docs** — update `chart_datum_node.cpp` header comment, `launch/chart_datum_launch.py`
+   (new params), and `README.md` for the config schema, override flag, `lake_datum`,
+   and ellipsoid-default behavior.
+
+## Files to Change
+
+| File | Change |
+|------|--------|
+| `include/mru_transform/datum_config.hpp` | New — pure types + `point_in_ring`/`load_datum_config`/`resolve` decls + `DatumSource` enum |
+| `src/datum_config.cpp` | New — implementations (yaml-cpp parse, ray-cast) |
+| `nodes/chart_datum_node.cpp` | VDatum optional; new params; resolution-chain `recalc`; `datum_source` publisher; provenance logging |
+| `config/datum_polygons.example.yaml` | New — documented schema + synthetic entry |
+| `launch/chart_datum_launch.py` | Surface new params |
+| `test/test_datum_config.cpp` | New — gtest for ring/parse/resolve |
+| `mru_transform/CMakeLists.txt` | Build `datum_config` lib, link yaml-cpp, register test |
+| `mru_transform/package.xml` | Add `yaml-cpp` (or `yaml_cpp_vendor`) depend |
+| `mru_transform/README.md` | Document config/params/fallback behavior |
+
+## Principles Self-Check
+
+| Principle | Consideration |
+|---|---|
+| A change includes its consequences | Plan checks `sea_surface_estimator` (same repo) tide-plausibility use of the datum; flags S57 `chart_layer` (other repo) as a verify-before-merge item (step 9 / Consequences). |
+| Human control & transparency | `datum_source` topic + per-change logging make provenance visible; override-vs-fallback is an explicit configurable flag. |
+| Test what breaks | Pure core is unit-tested across all four resolution paths + polygon edge cases. |
+| Workspace vs. project separation | Generic mechanism + synthetic example here; deployment-specific Massabesic polygon deferred to the platform overlay. |
+| Only what's needed | Single polygon representation (lat/lon ring; bbox expressible as a 4-point ring — no separate bbox type); ray-cast hand-rolled, no geometry dep. yaml-cpp is the one new dep, justified by the file-based schema the issue specifies. |
+
+## ADR Compliance
+
+| ADR | Triggered | How addressed |
+|---|---|---|
+| 0008 — ROS 2 conventions | Yes | Params declared with defaults; lifecycle pattern preserved; YAML config is conventional; target Rolling-compatible APIs. |
+| 0001 — ADRs | No (repo has no ADR log) | Capture "ellipsoid-default is safe" + override-ordering rationale in node header + README + PR body. |
+
+## Consequences
+
+| If we change... | Also update... | Included in plan? |
+|---|---|---|
+| Always-on `chart_datum` frame | `sea_surface_estimator` tide-plausibility bound (same repo) | Yes — verify in step 4/9 |
+| Datum semantics off-VDatum | S57 `chart_layer` depth→clearance (other repo) | No — verify-before-merge item; may need follow-up issue |
+| New TF frame behavior | Frame naming/parenting in #8 (vertical-datum hierarchy) | Open question — coordinate |
+| New params + config schema | `chart_datum_launch.py`, README | Yes |
+| Real Massabesic polygon | Platform/site overlay (echoboats) | No — follow-up issue in platform repo |
+
+## Open Questions
+
+- **Config format**: yaml-cpp file (assumed, per issue's "config file (path param)")
+  vs. ROS nested params. Plan assumes yaml-cpp — confirm acceptable to add the dep.
+- **Frame naming**: should the ellipsoid-default frame keep the name `chart_datum`,
+  or get a distinct name so consumers can refuse it? Needs alignment with #8.
+- **`chart_layer` behavior** on an ellipsoid-referenced datum: tolerate, or skip
+  clearance conversion? Confirms whether a cross-repo follow-up is needed.
+
+## Estimated Scope
+
+Single PR for the mechanism + tests + example config in `mru_transform`. The real
+Massabesic polygon and any `chart_layer` change are separate follow-ups in their
+owning repos.

--- a/.agent/work-plans/issue-25/plan.md
+++ b/.agent/work-plans/issue-25/plan.md
@@ -15,11 +15,28 @@ from NOAA VDatum `.gtx` grids via PROJ. Two gaps block "works anywhere":
    gates publishing on that flag. Off-VDatum (e.g. Massabesic, inside the grid dir
    but outside coverage) **no `chart_datum` frame is published at all**.
 
-We add a resolution chain — VDatum → polygon config → `lake_datum` param →
-ellipsoid default — so a datum is always resolvable, with the source tracked and
-logged. The review comment (issue #25) flagged: keep deployment-specific polygon
-data out of this generic package, tag every datum with its provenance, and verify
-downstream consumers tolerate an always-on frame.
+We add a resolution chain — VDatum → polygon config → `lake_datum` param — that
+populates `chart_datum` from whichever real datum is available, tracking and
+logging the source. When **nothing** matches we leave `chart_datum` **absent**
+(per the resolved design below) and navigation continues on `map_tide`.
+
+### Resolved design decisions (issue #25 discussion, 2026-06-13)
+
+- **Q1 — config format: yaml-cpp file.** A standalone YAML file (`datum_config_path`
+  param) parsed with yaml-cpp; natural for variable-length polygon rings. One new,
+  well-established ROS 2 dependency.
+- **Q2 — "nothing matches": `chart_datum` absent + loud WARN** (NOT published at z=0).
+  This is the #8-designed "optional/additive" state for `chart_datum`. It honors
+  acceptance item 4's *intent* ("never hard-fail on datum") while reinterpreting its
+  *mechanism*: the safe default is "no chart_datum, nav continues on the ellipsoidal
+  `map`/`map_tide`," not "publish a chart_datum at the ellipsoid." Publishing z=0 would
+  assert a false `chart_datum == ellipsoid` equality and risk confidently-wrong
+  clearance in any consumer that ignored provenance.
+- **Q3 — no consumer change in scope.** Verified in code that both `chart_datum`
+  consumers already tolerate absence: `sea_surface_estimator` (this repo,
+  `is_out_of_range` try/catch → "don't filter") and `s57_layer` (`s57_tools`,
+  try/catch → keeps `tide_offset_=0`, raw chart depth). Absence off-VDatum is the
+  pre-existing status quo; this PR only *adds* real datums, never a wrong one.
 
 ## Approach
 
@@ -28,8 +45,7 @@ downstream consumers tolerate an always-on frame.
    `DatumEntry {name, ring<lat,lon>, chart_datum_z, optional mhhw_z}`,
    `point_in_ring()` (ray-cast), `load_datum_config(path)` (yaml-cpp parse),
    `resolve(lat, lon, entries) -> optional<DatumEntry>`. Pure logic so it unit-tests
-   without rclcpp. Define a `DatumSource` enum {VDATUM, POLYGON_CONFIG, PARAM,
-   ELLIPSOID_DEFAULT}.
+   without rclcpp. Define a `DatumSource` enum {VDATUM, POLYGON_CONFIG, PARAM, NONE}.
 2. **Make VDatum optional in `on_configure`** — if `vdatum_grid_dir` is empty or no
    MLLW grids found, skip PROJ setup and log once (INFO), do **not** FAILURE. Keep
    `geoid_grid` required only when VDatum is used. PROJ pointers stay null → guarded.
@@ -37,19 +53,19 @@ downstream consumers tolerate an always-on frame.
    (bool, false → config is a VDatum *fallback*; true → consult config *first*),
    `lake_datum` (double, NaN sentinel = unset; fixed datum-below-ellipsoid z),
    `lake_datum_mhhw` (double, NaN = unset). Declare/get in `on_configure`; load the
-   config file there if the path is set.
+   config file there if the path is set (yaml-cpp).
 4. **Rewrite `recalc_callback` as the resolution chain** producing
    `(chart_datum_z_, optional mhhw_z_, DatumSource, name)`:
    override-first config (if flag) → VDatum → fallback config → `lake_datum` param →
-   ellipsoid default (z=0). Always ends with a valid datum. Set `has_valid_mllw_` =
-   true in all branches; keep `has_valid_mhhw_` only when a source supplies MHHW.
-   Log the resolved source + name with `RCLCPP_INFO` on change (not just _ONCE, since
-   the source can change as the boat moves), and `RCLCPP_WARN` once when falling to
-   the ellipsoid default.
+   **NONE**. Set `has_valid_mllw_ = true` only when a real datum is found
+   (VDATUM/POLYGON_CONFIG/PARAM); on **NONE** set `has_valid_mllw_ = false` so
+   `publish_callback` naturally leaves `chart_datum` absent. Log the resolved source +
+   name with `RCLCPP_INFO` on change (source can change as the boat moves), and a
+   prominent `RCLCPP_WARN` (throttled) when the result is NONE.
 5. **Publish provenance** — add a latched `std_msgs::msg::String` publisher
-   `datum_source` (values like `"vdatum"`, `"polygon:Massabesic"`, `"param"`,
-   `"ellipsoid_default"`) so consumers/operators can distinguish a surveyed datum
-   from the safe fallback. Publish in `publish_callback` alongside the TF.
+   `datum_source` (`"vdatum"`, `"polygon:<name>"`, `"param"`, `"none"`) so
+   consumers/operators can see which datum is active and distinguish "no datum here"
+   from a surveyed one. Publish in `publish_callback` (including `"none"` when absent).
 6. **Ship a generic example config, not Massabesic data** —
    `config/datum_polygons.example.yaml` with a documented schema and one *synthetic*
    entry. The real Lake Massabesic polygon goes in the platform/site overlay
@@ -57,11 +73,11 @@ downstream consumers tolerate an always-on frame.
    acceptance item 6 in the right repo.
 7. **Tests** — `test/test_datum_config.cpp` (gtest): point-in-ring (inside, outside,
    on-boundary, ring that wraps longitude), config parse (valid/missing-file/malformed),
-   and `resolve()` precedence (override-first vs fallback; param override; ellipsoid
-   default when nothing matches). Register in `CMakeLists.txt`.
+   and `resolve()` precedence (override-first vs fallback; param override; NONE when
+   nothing matches). Register in `CMakeLists.txt`.
 8. **Docs** — update `chart_datum_node.cpp` header comment, `launch/chart_datum_launch.py`
    (new params), and `README.md` for the config schema, override flag, `lake_datum`,
-   and ellipsoid-default behavior.
+   and the absent-when-nothing-matches behavior.
 
 ## Files to Change
 
@@ -69,52 +85,49 @@ downstream consumers tolerate an always-on frame.
 |------|--------|
 | `include/mru_transform/datum_config.hpp` | New — pure types + `point_in_ring`/`load_datum_config`/`resolve` decls + `DatumSource` enum |
 | `src/datum_config.cpp` | New — implementations (yaml-cpp parse, ray-cast) |
-| `nodes/chart_datum_node.cpp` | VDatum optional; new params; resolution-chain `recalc`; `datum_source` publisher; provenance logging |
+| `nodes/chart_datum_node.cpp` | VDatum optional; new params; resolution-chain `recalc`; `datum_source` publisher; provenance logging; absent on NONE |
 | `config/datum_polygons.example.yaml` | New — documented schema + synthetic entry |
 | `launch/chart_datum_launch.py` | Surface new params |
 | `test/test_datum_config.cpp` | New — gtest for ring/parse/resolve |
 | `mru_transform/CMakeLists.txt` | Build `datum_config` lib, link yaml-cpp, register test |
 | `mru_transform/package.xml` | Add `yaml-cpp` (or `yaml_cpp_vendor`) depend |
-| `mru_transform/README.md` | Document config/params/fallback behavior |
+| `mru_transform/README.md` | Document config/params/absent-default behavior |
 
 ## Principles Self-Check
 
 | Principle | Consideration |
 |---|---|
-| A change includes its consequences | Plan checks `sea_surface_estimator` (same repo) tide-plausibility use of the datum; flags S57 `chart_layer` (other repo) as a verify-before-merge item (step 9 / Consequences). |
-| Human control & transparency | `datum_source` topic + per-change logging make provenance visible; override-vs-fallback is an explicit configurable flag. |
-| Test what breaks | Pure core is unit-tested across all four resolution paths + polygon edge cases. |
+| A change includes its consequences | Both consumers verified in code (try/catch tolerance); absent-default is the pre-existing state, so no consumer change is forced. |
+| Human control & transparency | `datum_source` topic + per-change logging make provenance visible (incl. `"none"`); override-vs-fallback is an explicit configurable flag. |
+| Test what breaks | Pure core is unit-tested across all resolution paths + polygon edge cases. |
 | Workspace vs. project separation | Generic mechanism + synthetic example here; deployment-specific Massabesic polygon deferred to the platform overlay. |
-| Only what's needed | Single polygon representation (lat/lon ring; bbox expressible as a 4-point ring — no separate bbox type); ray-cast hand-rolled, no geometry dep. yaml-cpp is the one new dep, justified by the file-based schema the issue specifies. |
+| Only what's needed | Single polygon representation (lat/lon ring; bbox = degenerate ring); ray-cast hand-rolled, no geometry dep. yaml-cpp is the one new dep, justified by the file-based schema the issue specifies. |
 
 ## ADR Compliance
 
 | ADR | Triggered | How addressed |
 |---|---|---|
 | 0008 — ROS 2 conventions | Yes | Params declared with defaults; lifecycle pattern preserved; YAML config is conventional; target Rolling-compatible APIs. |
-| 0001 — ADRs | No (repo has no ADR log) | Capture "ellipsoid-default is safe" + override-ordering rationale in node header + README + PR body. |
+| 0001 — ADRs | No (repo has no ADR log) | Capture the absent-default + override-ordering rationale in node header + README + PR body. |
 
 ## Consequences
 
-| If we change... | Also update... | Included in plan? |
+| If we change... | Also update... | Status |
 |---|---|---|
-| Always-on `chart_datum` frame | `sea_surface_estimator` tide-plausibility bound (same repo) | Yes — verify in step 4/9 |
-| Datum semantics off-VDatum | S57 `chart_layer` depth→clearance (other repo) | No — verify-before-merge item; may need follow-up issue |
-| New TF frame behavior | Frame naming/parenting in #8 (vertical-datum hierarchy) | Open question — coordinate |
-| New params + config schema | `chart_datum_launch.py`, README | Yes |
-| Real Massabesic polygon | Platform/site overlay (echoboats) | No — follow-up issue in platform repo |
+| Always-resolve datum chain | `sea_surface_estimator` tide-plausibility bound (same repo) | Verified — try/catch tolerates absence; no change |
+| Datum absent off-VDatum | `s57_layer` depth→clearance (`s57_tools`, cross-repo) | Verified — try/catch keeps `tide_offset_=0`; no change |
+| `chart_datum` semantics | Frame model in #8 (vertical-datum hierarchy) | Aligned — #8 defines `chart_datum` as optional/additive |
+| New params + config schema | `chart_datum_launch.py`, README | In plan (steps 3, 8) |
+| Real Massabesic polygon | Platform/site overlay (echoboats) | Follow-up issue in platform repo |
 
 ## Open Questions
 
-- **Config format**: yaml-cpp file (assumed, per issue's "config file (path param)")
-  vs. ROS nested params. Plan assumes yaml-cpp — confirm acceptable to add the dep.
-- **Frame naming**: should the ellipsoid-default frame keep the name `chart_datum`,
-  or get a distinct name so consumers can refuse it? Needs alignment with #8.
-- **`chart_layer` behavior** on an ellipsoid-referenced datum: tolerate, or skip
-  clearance conversion? Confirms whether a cross-repo follow-up is needed.
+- All resolved — see "Resolved design decisions" above (Q1 yaml-cpp, Q2 absent-default,
+  Q3 no consumer change). Acceptance item 4's mechanism was reinterpreted with the
+  issue author's sign-off; worth a one-line note on the issue so the record reflects it.
 
 ## Estimated Scope
 
 Single PR for the mechanism + tests + example config in `mru_transform`. The real
-Massabesic polygon and any `chart_layer` change are separate follow-ups in their
-owning repos.
+Massabesic polygon is a separate follow-up in the platform repo; no `s57_layer`
+change is needed.

--- a/.agent/work-plans/issue-25/plan.md
+++ b/.agent/work-plans/issue-25/plan.md
@@ -15,100 +15,125 @@ from NOAA VDatum `.gtx` grids via PROJ. Two gaps block "works anywhere":
    gates publishing on that flag. Off-VDatum (e.g. Massabesic, inside the grid dir
    but outside coverage) **no `chart_datum` frame is published at all**.
 
-We add a resolution chain — VDatum → polygon config → `lake_datum` param — that
-populates `chart_datum` from whichever real datum is available, tracking and
-logging the source. When **nothing** matches we leave `chart_datum` **absent**
-(per the resolved design below) and navigation continues on `map_tide`.
+We add a datum **resolution chain** that populates `chart_datum` from whichever real
+datum is available, tracking and logging the source. When **nothing** matches we
+leave `chart_datum` **absent** and navigation continues on `map_tide`.
 
-### Resolved design decisions (issue #25 discussion, 2026-06-13)
+### Resolution order (resolved 2026-06-13/14)
 
-- **Q1 — config format: yaml-cpp file.** A standalone YAML file (`datum_config_path`
-  param) parsed with yaml-cpp; natural for variable-length polygon rings. One new,
-  well-established ROS 2 dependency.
-- **Q2 — "nothing matches": `chart_datum` absent + loud WARN** (NOT published at z=0).
-  This is the #8-designed "optional/additive" state for `chart_datum`. It honors
-  acceptance item 4's *intent* ("never hard-fail on datum") while reinterpreting its
-  *mechanism*: the safe default is "no chart_datum, nav continues on the ellipsoidal
-  `map`/`map_tide`," not "publish a chart_datum at the ellipsoid." Publishing z=0 would
-  assert a false `chart_datum == ellipsoid` equality and risk confidently-wrong
-  clearance in any consumer that ignored provenance.
-- **Q3 — no consumer change in scope.** Verified in code that both `chart_datum`
-  consumers already tolerate absence: `sea_surface_estimator` (this repo,
-  `is_out_of_range` try/catch → "don't filter") and `s57_layer` (`s57_tools`,
-  try/catch → keeps `tide_offset_=0`, raw chart depth). Absence off-VDatum is the
-  pre-existing status quo; this PR only *adds* real datums, never a wrong one.
+1. **`lake_datum` param** — if set (NaN sentinel = unset), wins outright everywhere.
+   Deliberate operator action for one-offs/testing; least-surprising if it overrides
+   VDatum too. Source = `PARAM`.
+2. **config override-entries** — polygon entries flagged `override: true` whose ring
+   contains the point. Source = `POLYGON_CONFIG`.
+3. **VDatum** — PROJ pipeline result where grids cover the point. Source = `VDATUM`.
+4. **config fallback-entries** — polygon entries with `override: false` (the default)
+   whose ring contains the point. Source = `POLYGON_CONFIG`.
+5. **NONE** — `chart_datum` absent + loud WARN.
+
+Within a pass, the **first** matching entry in file order wins (documented).
+
+### Resolved design decisions (issue #25 discussion)
+
+- **Q1 — config format: yaml-cpp file** (`datum_config_path` param); natural for
+  variable-length polygon rings. One new, well-established ROS 2 dependency.
+- **Q2 — "nothing matches": `chart_datum` absent + loud WARN** (NOT z=0). This is
+  #8's "optional/additive" design for `chart_datum`. Honors acceptance item 4's
+  *intent* ("never hard-fail") while reinterpreting its *mechanism*: the safe default
+  is "no chart_datum, nav on the ellipsoidal `map`/`map_tide`," not a z=0 frame that
+  would assert a false `chart_datum == ellipsoid` equality.
+- **Q3 — no consumer change in scope.** Verified in code: `sea_surface_estimator`
+  (this repo) and `s57_layer` (`s57_tools`) both try/catch the lookup and degrade
+  safely. Absence off-VDatum is the pre-existing status quo; this PR only *adds* real
+  datums, never a wrong one.
+- **Q4 — config positioning: per-entry `override` flag (default false), two-pass
+  around VDatum** — NOT a single global flag. Lets one polygon override VDatum (a
+  trusted local survey) while another only fills gaps, without flipping the whole
+  file into override mode. Safe default (forgotten flag = fallback).
 
 ## Approach
 
-1. **Extract a pure, ROS-free resolution core** — new header
-   `include/mru_transform/datum_config.hpp` (+ `src/datum_config.cpp`):
-   `DatumEntry {name, ring<lat,lon>, chart_datum_z, optional mhhw_z}`,
-   `point_in_ring()` (ray-cast), `load_datum_config(path)` (yaml-cpp parse),
-   `resolve(lat, lon, entries) -> optional<DatumEntry>`. Pure logic so it unit-tests
-   without rclcpp. Define a `DatumSource` enum {VDATUM, POLYGON_CONFIG, PARAM, NONE}.
+1. **Pure, ROS-free resolution core** — `include/mru_transform/datum_config.hpp`
+   (+ `src/datum_config.cpp`). Types:
+   - `DatumEntry { std::string name; std::vector<std::pair<double,double>> ring;
+     double chart_datum_z; std::optional<double> mhhw_z; bool override_vdatum = false; }`
+   - `VDatumResult { double mllw_z; std::optional<double> mhhw_z; }`
+   - `DatumResult { DatumSource source; std::string name; double chart_datum_z;
+     std::optional<double> mhhw_z; }`, `enum class DatumSource {VDATUM, POLYGON_CONFIG, PARAM}`
+   Functions: `point_in_ring()` (ray-cast), `load_datum_config(path)` (yaml-cpp parse),
+   and the **whole precedence chain** as one pure function:
+   `std::optional<DatumResult> resolve_datum(lat, lon, lake_param, lake_mhhw_param,
+   std::optional<VDatumResult> vdatum, const std::vector<DatumEntry>& entries)`
+   returning `nullopt` for NONE. Encapsulating the chain here (not in the node) is
+   what makes the precedence matrix unit-testable — addresses plan-review finding 1.
 2. **Make VDatum optional in `on_configure`** — if `vdatum_grid_dir` is empty or no
    MLLW grids found, skip PROJ setup and log once (INFO), do **not** FAILURE. Keep
    `geoid_grid` required only when VDatum is used. PROJ pointers stay null → guarded.
-3. **Add parameters** — `datum_config_path` (string, ""), `datum_config_override`
-   (bool, false → config is a VDatum *fallback*; true → consult config *first*),
-   `lake_datum` (double, NaN sentinel = unset; fixed datum-below-ellipsoid z),
-   `lake_datum_mhhw` (double, NaN = unset). Declare/get in `on_configure`; load the
-   config file there if the path is set (yaml-cpp).
-4. **Rewrite `recalc_callback` as the resolution chain** producing
-   `(chart_datum_z_, optional mhhw_z_, DatumSource, name)`:
-   override-first config (if flag) → VDatum → fallback config → `lake_datum` param →
-   **NONE**. Set `has_valid_mllw_ = true` only when a real datum is found
-   (VDATUM/POLYGON_CONFIG/PARAM); on **NONE** set `has_valid_mllw_ = false` so
-   `publish_callback` naturally leaves `chart_datum` absent. Log the resolved source +
-   name with `RCLCPP_INFO` on change (source can change as the boat moves), and a
-   prominent `RCLCPP_WARN` (throttled) when the result is NONE.
-5. **Publish provenance** — add a latched `std_msgs::msg::String` publisher
-   `datum_source` (`"vdatum"`, `"polygon:<name>"`, `"param"`, `"none"`) so
-   consumers/operators can see which datum is active and distinguish "no datum here"
-   from a surveyed one. Publish in `publish_callback` (including `"none"` when absent).
+3. **Add parameters** — `datum_config_path` (string, ""), `lake_datum` (double, NaN =
+   unset; fixed datum-below-ellipsoid z), `lake_datum_mhhw` (double, NaN = unset).
+   (No global override flag — per-entry now.) Declare/get in `on_configure`; load the
+   config file there if the path is set (yaml-cpp); each entry parses its optional
+   `override` field (default false).
+4. **`recalc_callback` becomes thin** — query PROJ for an `optional<VDatumResult>`
+   (nullopt when no coverage / VDatum disabled), read the params, call
+   `resolve_datum(...)`. On a result: set `chart_datum_z_`, optional `mhhw_z_`, source,
+   name; `has_valid_mllw_ = true`; `has_valid_mhhw_` only if the result carries MHHW.
+   On `nullopt`: `has_valid_mllw_ = false` so `publish_callback` leaves `chart_datum`
+   absent, plus a throttled `RCLCPP_WARN`. Log the source+name with `RCLCPP_INFO` on
+   change (source can change as the boat moves).
+5. **Publish provenance** — latched `std_msgs::msg::String` publisher `datum_source`
+   (`"vdatum"`, `"polygon:<name>"`, `"param"`, `"none"`) so consumers/operators can
+   distinguish "no datum here" from a surveyed one. Publish in `publish_callback`
+   (including `"none"` when absent).
 6. **Ship a generic example config, not Massabesic data** —
-   `config/datum_polygons.example.yaml` with a documented schema and one *synthetic*
-   entry. The real Lake Massabesic polygon goes in the platform/site overlay
-   (echoboats/bizzy) as a follow-up, passed via `datum_config_path`. Satisfies
-   acceptance item 6 in the right repo.
-7. **Tests** — `test/test_datum_config.cpp` (gtest): point-in-ring (inside, outside,
-   on-boundary, ring that wraps longitude), config parse (valid/missing-file/malformed),
-   and `resolve()` precedence (override-first vs fallback; param override; NONE when
-   nothing matches). Register in `CMakeLists.txt`.
-8. **Docs** — update `chart_datum_node.cpp` header comment, `launch/chart_datum_launch.py`
-   (new params), and `README.md` for the config schema, override flag, `lake_datum`,
-   and the absent-when-nothing-matches behavior.
+   `config/datum_polygons.example.yaml` with a documented schema (including the
+   `override` field) and one *synthetic* entry. Real Lake Massabesic polygon goes in
+   the platform/site overlay (echoboats/bizzy) as a follow-up, via `datum_config_path`.
+   Satisfies acceptance item 6 in the right repo.
+7. **Tests** — `test/test_datum_config.cpp` (gtest):
+   - `point_in_ring`: inside, outside, on-boundary, overlapping-rings first-match,
+     antimeridian limitation (documented, not handled).
+   - `load_datum_config`: valid, missing-file, malformed, `override` default false.
+   - `resolve_datum` precedence matrix: param-first-wins; override-entry beats VDatum;
+     fallback-entry loses to VDatum; fallback-entry fills a VDatum gap; NONE when
+     nothing matches; MHHW present vs absent. This covers acceptance item 5's matrix
+     in pure code (the PROJ query itself is the only untested seam).
+   Register in `CMakeLists.txt`.
+8. **Docs** — `chart_datum_node.cpp` header, `launch/chart_datum_launch.py` (new
+   params), `README.md`: config schema + `override` semantics, resolution order,
+   `lake_datum`, absent-when-nothing-matches, and the note that a `chart_datum`-only
+   datum (no MHHW) leaves `sea_surface_estimator`'s tide-plausibility bound disabled.
 
 ## Files to Change
 
 | File | Change |
 |------|--------|
-| `include/mru_transform/datum_config.hpp` | New — pure types + `point_in_ring`/`load_datum_config`/`resolve` decls + `DatumSource` enum |
-| `src/datum_config.cpp` | New — implementations (yaml-cpp parse, ray-cast) |
-| `nodes/chart_datum_node.cpp` | VDatum optional; new params; resolution-chain `recalc`; `datum_source` publisher; provenance logging; absent on NONE |
-| `config/datum_polygons.example.yaml` | New — documented schema + synthetic entry |
+| `include/mru_transform/datum_config.hpp` | New — `DatumEntry`/`VDatumResult`/`DatumResult`/`DatumSource` + `point_in_ring`/`load_datum_config`/`resolve_datum` decls |
+| `src/datum_config.cpp` | New — implementations (yaml-cpp parse, ray-cast, full precedence chain) |
+| `nodes/chart_datum_node.cpp` | VDatum optional; new params; thin `recalc` delegating to `resolve_datum`; `datum_source` publisher; absent on NONE |
+| `config/datum_polygons.example.yaml` | New — documented schema (incl. `override`) + synthetic entry |
 | `launch/chart_datum_launch.py` | Surface new params |
-| `test/test_datum_config.cpp` | New — gtest for ring/parse/resolve |
-| `mru_transform/CMakeLists.txt` | Build `datum_config` lib, link yaml-cpp, register test |
+| `test/test_datum_config.cpp` | New — gtest for ring/parse/resolve precedence matrix |
+| `mru_transform/CMakeLists.txt` | Build `datum_config` lib, link yaml-cpp, register test, `install(DIRECTORY config ...)` |
 | `mru_transform/package.xml` | Add `yaml-cpp` (or `yaml_cpp_vendor`) depend |
-| `mru_transform/README.md` | Document config/params/absent-default behavior |
+| `mru_transform/README.md` | Document config/params/resolution order/absent-default |
 
 ## Principles Self-Check
 
 | Principle | Consideration |
 |---|---|
-| A change includes its consequences | Both consumers verified in code (try/catch tolerance); absent-default is the pre-existing state, so no consumer change is forced. |
-| Human control & transparency | `datum_source` topic + per-change logging make provenance visible (incl. `"none"`); override-vs-fallback is an explicit configurable flag. |
-| Test what breaks | Pure core is unit-tested across all resolution paths + polygon edge cases. |
-| Workspace vs. project separation | Generic mechanism + synthetic example here; deployment-specific Massabesic polygon deferred to the platform overlay. |
-| Only what's needed | Single polygon representation (lat/lon ring; bbox = degenerate ring); ray-cast hand-rolled, no geometry dep. yaml-cpp is the one new dep, justified by the file-based schema the issue specifies. |
+| A change includes its consequences | Both consumers verified (try/catch tolerance); MHHW-absent interaction documented; absent-default is pre-existing so no consumer change forced. |
+| Human control & transparency | `datum_source` topic + per-change logging make provenance visible (incl. `"none"`); per-entry `override` is explicit and defaults safe. |
+| Test what breaks | Full precedence chain is pure → the whole matrix (param/override/fallback/VDatum/none/MHHW) is unit-tested. |
+| Workspace vs. project separation | Generic mechanism + synthetic example here; Massabesic polygon deferred to the platform overlay. |
+| Only what's needed | Single polygon representation; per-entry `override` is ~1 bool + a two-pass loop over the global-flag alternative, and it removes a footgun rather than adding speculative surface. yaml-cpp is the one new dep. |
 
 ## ADR Compliance
 
 | ADR | Triggered | How addressed |
 |---|---|---|
-| 0008 — ROS 2 conventions | Yes | Params declared with defaults; lifecycle pattern preserved; YAML config is conventional; target Rolling-compatible APIs. |
-| 0001 — ADRs | No (repo has no ADR log) | Capture the absent-default + override-ordering rationale in node header + README + PR body. |
+| 0008 — ROS 2 conventions | Yes | Params declared with defaults; lifecycle pattern preserved; YAML config conventional; target Rolling-compatible APIs. |
+| 0001 — ADRs | No (repo has no ADR log) | Capture absent-default + resolution-order rationale in node header + README + PR body. |
 
 ## Consequences
 
@@ -116,15 +141,17 @@ logging the source. When **nothing** matches we leave `chart_datum` **absent**
 |---|---|---|
 | Always-resolve datum chain | `sea_surface_estimator` tide-plausibility bound (same repo) | Verified — try/catch tolerates absence; no change |
 | Datum absent off-VDatum | `s57_layer` depth→clearance (`s57_tools`, cross-repo) | Verified — try/catch keeps `tide_offset_=0`; no change |
+| chart_datum-only entry (no MHHW) | tide-plausibility bound silently disabled (mhhw lookup throws → no-filter) | Documented in step 8; acceptable degradation |
 | `chart_datum` semantics | Frame model in #8 (vertical-datum hierarchy) | Aligned — #8 defines `chart_datum` as optional/additive |
 | New params + config schema | `chart_datum_launch.py`, README | In plan (steps 3, 8) |
 | Real Massabesic polygon | Platform/site overlay (echoboats) | Follow-up issue in platform repo |
 
 ## Open Questions
 
-- All resolved — see "Resolved design decisions" above (Q1 yaml-cpp, Q2 absent-default,
-  Q3 no consumer change). Acceptance item 4's mechanism was reinterpreted with the
-  issue author's sign-off; worth a one-line note on the issue so the record reflects it.
+- All resolved — Q1 yaml-cpp; Q2 absent-default; Q3 no consumer change; Q4 per-entry
+  `override` (default false) + `lake_datum` param first. Acceptance item 4's mechanism
+  was reinterpreted with the issue author's sign-off; worth a one-line note on the
+  issue so the record reflects it.
 
 ## Estimated Scope
 

--- a/.agent/work-plans/issue-25/plan.md
+++ b/.agent/work-plans/issue-25/plan.md
@@ -116,7 +116,7 @@ Within a pass, the **first** matching entry in file order wins (documented).
 | `test/test_datum_config.cpp` | New — gtest for ring/parse/resolve precedence matrix |
 | `mru_transform/CMakeLists.txt` | Build `datum_config` lib, link yaml-cpp, register test, `install(DIRECTORY config ...)` |
 | `mru_transform/package.xml` | Add `yaml-cpp` (or `yaml_cpp_vendor`) depend |
-| `mru_transform/README.md` | Document config/params/resolution order/absent-default |
+| `README.md` (repo root) | Document config/params/resolution order/absent-default |
 
 ## Principles Self-Check
 

--- a/.agent/work-plans/issue-25/progress.md
+++ b/.agent/work-plans/issue-25/progress.md
@@ -1,0 +1,23 @@
+---
+issue: 25
+---
+
+# Issue #25 — Datum support off-VDatum: polygon-keyed datum config (always-on) + lake_datum override
+
+## Issue Review
+**Status**: complete
+**When**: 2026-06-13 (local)
+**By**: Claude Code Agent (Claude Opus 4.8 (1M context))
+
+**Issue**: #25
+**Comment**: https://github.com/rolker/mru_transform/issues/25#issuecomment-4700414622
+**Scope verdict**: well-scoped
+
+### Actions
+- [ ] Keep Massabesic polygon data out of the generic `mru_transform` package — ship loader + synthetic example schema here; put the real Massabesic polygon in the platform/site overlay (acceptance item 6).
+- [ ] Verify and state in the PR that both downstream consumers (S57 `chart_layer` depth→clearance, `sea_surface_estimator` tide plausibility bound) behave correctly given the new always-on frame, and can distinguish the ellipsoid fallback from a surveyed tidal datum.
+- [ ] Tag each published datum with its provenance (VDatum / polygon / param / ellipsoid-default) in logs/diagnostics so the safe default is never mistaken for a real datum (safety / silent-wrong-data).
+- [ ] Coordinate the new always-published datum frame's naming/parenting with #8 (Marine TF vertical-datum hierarchy).
+- [ ] Prefer a single polygon representation; avoid adding a new geometry dependency for point-in-polygon.
+- [ ] Capture the "ellipsoid-default is safe" rationale + override-first-vs-fallback semantics durably (PR body / node header doc; ADR if adopted).
+- [ ] Document the new config-path param, override-ordering flag, `lake_datum`, and ellipsoid-default behavior in the node header, `chart_datum_launch.py`, and README.

--- a/.agent/work-plans/issue-25/progress.md
+++ b/.agent/work-plans/issue-25/progress.md
@@ -70,9 +70,9 @@ issue: 25
 - [x] (suggestion) load_datum_config threw raw YAML::Exception, breaking its std::runtime_error contract — fixed (wrap+rethrow)
 - [x] (suggestion) test gaps: collinear-outside / vertex-latitude / concave point_in_ring; malformed-vertex + non-numeric parse — added (21 gtests)
 - [x] (suggestion) plan README path nit (repo root, not mru_transform/) — fixed
-- [ ] (open — design decision) config-load failure returns CallbackReturn::FAILURE; reviewer argues degrade-to-empty + loud ERROR is more consistent with VDatum-optional / "works anywhere" (a config typo currently disables working VDatum too) — awaiting Roland's call
-- [ ] (follow-up, cross-repo) s57_layer keeps stale tide_offset_ when datum→none; new datum_source=="none" is the clean signal to clear it — file against s57_tools
-- [ ] (follow-up, same repo, separate node) sea_surface_estimator can't distinguish "no datum" from "MLLW present, MHHW missing"; could WARN when chart_datum resolves but mhhw doesn't
+- [x] (design decision) config-load failure returns CallbackReturn::FAILURE — RESOLVED: keep FAILURE (Roland, 2026-06-14); operator set the path deliberately, so a broken file should stop the node loudly
+- [x] (follow-up, cross-repo) s57_layer stale tide_offset_ when datum→none → filed s57_tools#26
+- [x] (follow-up, same repo, separate node) sea_surface_estimator warn when chart_datum present but MHHW missing → filed mru_transform#27
 
 ### Governance / plan adherence
 All principles Pass (Capture-decisions: Watch — VDatum-now-optional lives in code/commit, repo has no ADR system). ADR-0008 compliant. Plan adherence: faithful; no scope creep; all 9 planned files changed.

--- a/.agent/work-plans/issue-25/progress.md
+++ b/.agent/work-plans/issue-25/progress.md
@@ -51,3 +51,28 @@ issue: 25
 - [ ] (suggestion) Document/decide: a chart_datum-only entry (no mhhw) silently disables sea_surface_estimator's tide-plausibility bound (mhhw lookup throws → don't-filter) — `plan.md` step 4
 - [ ] (suggestion) Specify overlapping-polygon first-match semantics + antimeridian limitation of raw lat/lon ray-cast in schema docs — `plan.md` steps 1,8
 - [ ] (nit) `lake_datum` is a deployment-flavored name for a generic fixed-datum override — conscious choice per issue
+
+## Local Review (Pre-Push)
+**Status**: complete
+**When**: 2026-06-14 (local)
+**By**: Claude Code Agent (Claude Opus 4.8 (1M context))
+**Verdict**: approved
+
+**Branch**: feature/issue-25 at `248e098`
+**Mode**: pre-push
+**Depth**: Deep (reason: ~820 lines, lifecycle node, safety-relevant datum, cross-layer consumers)
+**Must-fix**: 0 remaining (2 fixed) | **Suggestions**: 4 fixed, 1 open design decision, 2 cross-repo follow-ups
+
+### Findings
+- [x] (must-fix) publish_rate/recalc_interval ≤ 0 unvalidated → silent never-publish / pegged core — fixed in `chart_datum_node.cpp` on_configure
+- [x] (must-fix) datum_source_pub_ post-cleanup null-publish window (asymmetry vs mllw/mhhw pubs) — fixed by dropping the on_cleanup reset
+- [x] (suggestion) lake_datum ±Inf bypassed the NaN sentinel → could reach TF — fixed via std::isfinite + isinf warn
+- [x] (suggestion) load_datum_config threw raw YAML::Exception, breaking its std::runtime_error contract — fixed (wrap+rethrow)
+- [x] (suggestion) test gaps: collinear-outside / vertex-latitude / concave point_in_ring; malformed-vertex + non-numeric parse — added (21 gtests)
+- [x] (suggestion) plan README path nit (repo root, not mru_transform/) — fixed
+- [ ] (open — design decision) config-load failure returns CallbackReturn::FAILURE; reviewer argues degrade-to-empty + loud ERROR is more consistent with VDatum-optional / "works anywhere" (a config typo currently disables working VDatum too) — awaiting Roland's call
+- [ ] (follow-up, cross-repo) s57_layer keeps stale tide_offset_ when datum→none; new datum_source=="none" is the clean signal to clear it — file against s57_tools
+- [ ] (follow-up, same repo, separate node) sea_surface_estimator can't distinguish "no datum" from "MLLW present, MHHW missing"; could WARN when chart_datum resolves but mhhw doesn't
+
+### Governance / plan adherence
+All principles Pass (Capture-decisions: Watch — VDatum-now-optional lives in code/commit, repo has no ADR system). ADR-0008 compliant. Plan adherence: faithful; no scope creep; all 9 planned files changed.

--- a/.agent/work-plans/issue-25/progress.md
+++ b/.agent/work-plans/issue-25/progress.md
@@ -35,3 +35,19 @@ issue: 25
 - [ ] Config format: confirm adding yaml-cpp dep for the file-based polygon config (vs ROS nested params).
 - [ ] Frame naming: should the ellipsoid-default frame keep `chart_datum` or get a distinct name consumers can refuse? Align with #8.
 - [ ] `chart_layer` behavior on an ellipsoid-referenced datum (tolerate vs skip clearance) — confirms whether a cross-repo follow-up is needed.
+
+## Plan Review
+**Status**: complete
+**When**: 2026-06-13 (local)
+**By**: Claude Code Agent (Claude Opus 4.8 (1M context)) (in-context — author self-review)
+
+**Plan**: `.agent/work-plans/issue-25/plan.md` at `1584e96`
+**PR**: https://github.com/rolker/mru_transform/pull/26
+**Verdict**: approve-with-suggestions
+
+### Findings
+- [ ] (must-fix) Precedence logic lives in untested node code — widen pure `resolve()` to take the optional VDatum result + config + param + override flag and return final (source, datum), so acceptance item 5's matrix is unit-testable — `plan.md` steps 1,4,7
+- [ ] (suggestion) Add `install(DIRECTORY config ...)` so `datum_polygons.example.yaml` ships (config/ not installed today) — `plan.md` step 6
+- [ ] (suggestion) Document/decide: a chart_datum-only entry (no mhhw) silently disables sea_surface_estimator's tide-plausibility bound (mhhw lookup throws → don't-filter) — `plan.md` step 4
+- [ ] (suggestion) Specify overlapping-polygon first-match semantics + antimeridian limitation of raw lat/lon ray-cast in schema docs — `plan.md` steps 1,8
+- [ ] (nit) `lake_datum` is a deployment-flavored name for a generic fixed-datum override — conscious choice per issue

--- a/.agent/work-plans/issue-25/progress.md
+++ b/.agent/work-plans/issue-25/progress.md
@@ -21,3 +21,17 @@ issue: 25
 - [ ] Prefer a single polygon representation; avoid adding a new geometry dependency for point-in-polygon.
 - [ ] Capture the "ellipsoid-default is safe" rationale + override-first-vs-fallback semantics durably (PR body / node header doc; ADR if adopted).
 - [ ] Document the new config-path param, override-ordering flag, `lake_datum`, and ellipsoid-default behavior in the node header, `chart_datum_launch.py`, and README.
+
+## Plan Authored
+**Status**: complete
+**When**: 2026-06-13 (local)
+**By**: Claude Code Agent (Claude Opus 4.8 (1M context))
+
+**Plan**: `.agent/work-plans/issue-25/plan.md` at `cc56d18`
+**PR**: https://github.com/rolker/mru_transform/pull/26 (`[PLAN]` prefix)
+**Phases**: single
+
+### Open questions
+- [ ] Config format: confirm adding yaml-cpp dep for the file-based polygon config (vs ROS nested params).
+- [ ] Frame naming: should the ellipsoid-default frame keep `chart_datum` or get a distinct name consumers can refuse? Align with #8.
+- [ ] `chart_layer` behavior on an ellipsoid-referenced datum (tolerate vs skip clearance) — confirms whether a cross-repo follow-up is needed.

--- a/README.md
+++ b/README.md
@@ -60,6 +60,58 @@ Override the frame_id's which default to `base_link`, `map` and `odom`.
 
 The topic used to publish odometry messages. Defaults to `odom`.
 
+## chart_datum_node
+
+`chart_datum_node` publishes the `map → chart_datum` (MLLW) and
+`map → chart_datum_mhhw` TF transforms — the static vertical offset between the
+WGS84 ellipsoid (`map`) and the chart datum at the boat's current position. It
+resolves the datum from several sources so the boat works on and off NOAA VDatum
+coverage (e.g. inland lakes).
+
+### Resolution order
+
+At each recompute the datum is resolved by this precedence (first match wins;
+within a config pass, the first matching entry in file order wins):
+
+1. **`lake_datum` param** (if set) — wins outright everywhere.
+2. **config entries with `override: true`** whose polygon contains the boat.
+3. **VDatum** (PROJ + NOAA grids) where it has coverage.
+4. **config entries with `override: false`** (the default) whose polygon
+   contains the boat — fills VDatum gaps.
+5. **Nothing matches** — `chart_datum` is **not published**; navigation
+   continues on the ellipsoidal `map` / `map_tide`, and a warning is logged.
+   (`chart_datum` is intentionally optional, per the marine TF frame design.)
+
+The active source is logged on change and published on the latched
+`datum_source` topic (`std_msgs/String`: `vdatum`, `polygon:<name>`, `param`, or
+`none`) so consumers and operators can tell a surveyed datum from `none`.
+
+### Parameters
+
+| Parameter | Default | Description |
+|---|---|---|
+| `geoid_grid` | `""` | PROJ geoid grid (`.tif`) for ellipsoid → NAVD88. Needed for VDatum. |
+| `vdatum_grid_dir` | `""` | Directory of VDatum `*_mllw.gtx` / `*_mhhw.gtx` grids. Empty disables VDatum (non-fatal). |
+| `datum_config_path` | `""` | Path to a polygon→datum YAML (see `config/datum_polygons.example.yaml`). Empty = none. A malformed file fails `on_configure`. |
+| `lake_datum` | NaN (unset) | Fixed `chart_datum` height (m, rel. ellipsoid) that overrides VDatum/config everywhere. For quick one-offs/testing. |
+| `lake_datum_mhhw` | NaN (unset) | Optional fixed MHHW height to accompany `lake_datum`. |
+| `recalc_interval` | `60.0` | Seconds between position-based datum recomputes. |
+| `publish_rate` | `1.0` | Hz at which cached transforms are republished. |
+
+### Config file
+
+See [`config/datum_polygons.example.yaml`](mru_transform/config/datum_polygons.example.yaml)
+for the schema. Heights are signed metres relative to the WGS84 ellipsoid
+(negative when the datum is below it), matching the published `map → chart_datum`
+translation. **Deployment-specific polygons** (e.g. a real Lake Massabesic datum)
+belong in the platform/site config repo, not this generic package — this package
+ships only a synthetic example.
+
+> An entry that sets `chart_datum_z` but omits `mhhw_z` publishes `chart_datum`
+> without `chart_datum_mhhw`. Downstream, `sea_surface_estimator`'s tide
+> plausibility bound needs both frames, so it stays disabled (no-op) for such an
+> entry — an acceptable degradation, but worth knowing.
+
 ## Credits
 
 Originally Developed by: Roland Arsenault,  University of New Hampshire [Center for Coastal and Ocean Mapping](https://github.com/CCOMJHC)

--- a/mru_transform/CMakeLists.txt
+++ b/mru_transform/CMakeLists.txt
@@ -26,6 +26,29 @@ find_package(tf2_ros REQUIRED)
 find_package(PkgConfig REQUIRED)
 pkg_check_modules(PROJ REQUIRED IMPORTED_TARGET proj)
 
+find_package(yaml-cpp REQUIRED)
+# yaml-cpp 0.8 exports the namespaced target; older versions export a bare one.
+if(TARGET yaml-cpp::yaml-cpp)
+  set(YAML_CPP_TARGET yaml-cpp::yaml-cpp)
+else()
+  set(YAML_CPP_TARGET yaml-cpp)
+endif()
+
+
+############################
+## datum resolution core  ##
+############################
+
+# Pure, ROS-free polygon/param/VDatum precedence resolution. Shared by
+# chart_datum_node and its unit test so the precedence is unit-testable.
+add_library(datum_config SHARED src/datum_config.cpp)
+target_include_directories(datum_config PUBLIC
+  "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+  "$<INSTALL_INTERFACE:include/${PROJECT_NAME}>"
+)
+target_link_libraries(datum_config ${YAML_CPP_TARGET})
+install(TARGETS datum_config LIBRARY DESTINATION lib)
+
 
 #############
 ## library ##
@@ -155,6 +178,7 @@ add_executable(
 )
 
 target_link_libraries(chart_datum_node
+  datum_config
   rclcpp::rclcpp
   rclcpp_lifecycle::rclcpp_lifecycle
   ${geometry_msgs_TARGETS}
@@ -173,6 +197,10 @@ install(TARGETS chart_datum_node
 )
 
 install(DIRECTORY launch
+  DESTINATION share/${PROJECT_NAME}/
+)
+
+install(DIRECTORY config
   DESTINATION share/${PROJECT_NAME}/
 )
 
@@ -311,6 +339,15 @@ if(BUILD_TESTING)
     ${sensor_msgs_TARGETS}
   )
   target_include_directories(test_subscribe_once PRIVATE
+    "${CMAKE_CURRENT_SOURCE_DIR}/include"
+  )
+
+  # Issue #25: datum resolution precedence + point-in-polygon + config parsing.
+  ament_add_gtest(test_datum_config test/test_datum_config.cpp)
+  target_link_libraries(test_datum_config
+    datum_config
+  )
+  target_include_directories(test_datum_config PRIVATE
     "${CMAKE_CURRENT_SOURCE_DIR}/include"
   )
 endif()

--- a/mru_transform/config/datum_polygons.example.yaml
+++ b/mru_transform/config/datum_polygons.example.yaml
@@ -1,0 +1,38 @@
+# Example polygon→datum configuration for chart_datum_node.
+#
+# Pass the path to this file via the `datum_config_path` parameter. Each entry
+# maps a geographic polygon to a vertical datum. The node looks up the boat's
+# current position and resolves the datum in this order:
+#
+#   1. lake_datum param (if set)              — wins everywhere
+#   2. entries with `override: true`  whose ring contains the point
+#   3. VDatum (NOAA grids), where it has coverage
+#   4. entries with `override: false` (default) whose ring contains the point
+#   5. nothing matches → chart_datum is NOT published (nav uses map_tide)
+#
+# Within a pass, the first matching entry in file order wins.
+#
+# Heights (chart_datum_z, mhhw_z) are signed metres in the SAME convention as
+# the published map→chart_datum transform: the datum's height relative to the
+# WGS84 ellipsoid (negative when the datum lies below the ellipsoid).
+#
+# NOTE: this is a SYNTHETIC example, not a surveyed value. Real, deployment-
+# specific polygons (e.g. Lake Massabesic) belong in your platform/site config
+# repo, not in this generic package.
+#
+# Rings are simple lat/lon polygons; a point on an edge counts as inside. Rings
+# crossing the ±180° antimeridian are not supported (fine for local areas).
+
+datum_polygons:
+  - name: "Example Lake (synthetic)"
+    # override: false        # (default) only used where VDatum has no coverage.
+                             # Set true to win over VDatum inside this ring.
+    chart_datum_z: -25.0     # SYNTHETIC placeholder — replace per deployment.
+    mhhw_z: -24.7            # optional; omit to leave the MHHW frame unpublished
+                             # (which leaves sea_surface_estimator's tide
+                             #  plausibility bound disabled there).
+    ring:                    # [latitude, longitude] vertices, degrees
+      - [43.000, -71.410]
+      - [43.000, -71.380]
+      - [42.980, -71.380]
+      - [42.980, -71.410]

--- a/mru_transform/include/mru_transform/datum_config.hpp
+++ b/mru_transform/include/mru_transform/datum_config.hpp
@@ -1,0 +1,89 @@
+// datum_config.hpp — Pure, ROS-free datum resolution for chart_datum_node.
+//
+// chart_datum_node resolves the vertical datum at the boat's position from
+// several sources. This header holds the source-agnostic core so the full
+// precedence chain is unit-testable without rclcpp or PROJ:
+//
+//   1. lake_datum param (if set)            — wins outright everywhere
+//   2. config entries with override == true — beat VDatum
+//   3. VDatum (PROJ) result                 — where grids cover the point
+//   4. config entries with override == false (default) — fill VDatum gaps
+//   5. nothing matches                      — caller leaves chart_datum absent
+//
+// Within a pass, the first matching entry (file order) wins.
+
+#ifndef MRU_TRANSFORM__DATUM_CONFIG_HPP_
+#define MRU_TRANSFORM__DATUM_CONFIG_HPP_
+
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace mru_transform
+{
+
+enum class DatumSource
+{
+  VDATUM,
+  POLYGON_CONFIG,
+  PARAM,
+};
+
+// A geographic point in degrees.
+struct LatLon
+{
+  double lat;
+  double lon;
+};
+
+// One polygon→datum entry from the config file. Heights are signed metres in
+// the same convention as the published map→chart_datum transform: the datum's
+// height relative to the WGS84 ellipsoid (negative when below the ellipsoid).
+struct DatumEntry
+{
+  std::string name;
+  std::vector<LatLon> ring;          // polygon vertices, degrees (>= 3)
+  double chart_datum_z = 0.0;        // chart datum height rel. ellipsoid (m)
+  std::optional<double> mhhw_z;      // optional MHHW height rel. ellipsoid (m)
+  bool override_vdatum = false;      // true → consulted before VDatum
+};
+
+// Result of a VDatum/PROJ query at a point (caller passes nullopt for no
+// coverage / VDatum disabled).
+struct VDatumResult
+{
+  double mllw_z;                     // MLLW height rel. ellipsoid (m)
+  std::optional<double> mhhw_z;      // MHHW height rel. ellipsoid (m), if any
+};
+
+// The resolved datum and where it came from.
+struct DatumResult
+{
+  DatumSource source;
+  std::string name;                  // "vdatum", the polygon name, or "param"
+  double chart_datum_z;
+  std::optional<double> mhhw_z;
+};
+
+// Ray-casting point-in-polygon test. `ring` is an open polygon (the closing
+// edge from last→first vertex is implied). Points on an edge count as inside.
+// Operates in raw lat/lon degrees: correct for local polygons; rings crossing
+// the ±180° antimeridian are NOT supported.
+bool point_in_ring(double lat, double lon, const std::vector<LatLon> & ring);
+
+// Parse a polygon→datum config file (YAML). Throws std::runtime_error on a
+// missing file or malformed content.
+std::vector<DatumEntry> load_datum_config(const std::string & path);
+
+// Resolve the datum at a point following the precedence chain documented above.
+// Returns nullopt when nothing matches (caller leaves chart_datum absent).
+std::optional<DatumResult> resolve_datum(
+  double lat, double lon,
+  std::optional<double> lake_datum,
+  std::optional<double> lake_datum_mhhw,
+  const std::optional<VDatumResult> & vdatum,
+  const std::vector<DatumEntry> & entries);
+
+}  // namespace mru_transform
+
+#endif  // MRU_TRANSFORM__DATUM_CONFIG_HPP_

--- a/mru_transform/launch/chart_datum_launch.py
+++ b/mru_transform/launch/chart_datum_launch.py
@@ -25,12 +25,23 @@ def generate_launch_description():
     vdatum_grid_dir_arg = DeclareLaunchArgument(
         'vdatum_grid_dir',
         default_value=os.path.join(_SHARE, 'data', 'vdatum'),
-        description='Directory containing VDatum *_mllw.gtx grids',
+        description='Directory containing VDatum *_mllw.gtx grids '
+                    '(empty disables VDatum)',
+    )
+
+    datum_config_path_arg = DeclareLaunchArgument(
+        'datum_config_path',
+        default_value='',
+        description='Path to a polygon→datum YAML config (see '
+                    'config/datum_polygons.example.yaml). Empty = none. '
+                    'Deployment-specific polygons belong in the platform/site '
+                    'config, not this package.',
     )
 
     return LaunchDescription([
         geoid_grid_arg,
         vdatum_grid_dir_arg,
+        datum_config_path_arg,
         LifecycleNode(
             package='mru_transform',
             executable='chart_datum_node',
@@ -42,7 +53,11 @@ def generate_launch_description():
             parameters=[{
                 'geoid_grid': LaunchConfiguration('geoid_grid'),
                 'vdatum_grid_dir': LaunchConfiguration('vdatum_grid_dir'),
+                'datum_config_path': LaunchConfiguration('datum_config_path'),
             }],
+            # The fixed-value override `lake_datum` (and `lake_datum_mhhw`) are
+            # node parameters; set them via a param file or `--ros-args -p`
+            # for a quick one-off (NaN/unset by default).
         ),
         LifecycleTransition(
             lifecycle_node_names=(

--- a/mru_transform/nodes/chart_datum_node.cpp
+++ b/mru_transform/nodes/chart_datum_node.cpp
@@ -1,22 +1,35 @@
 // chart_datum_node.cpp — Publishes map → chart_datum TF transforms
 //
-// Uses PROJ to compute the static vertical offset between the WGS84
-// ellipsoid (map frame) and tidal datums (MLLW, MHHW) at the robot's
-// current position. The offsets are position-dependent and recalculated
-// periodically. Transforms are published at a faster rate using
-// cached values.
+// Resolves the vertical datum (MLLW, and optionally MHHW) at the robot's
+// current position from a precedence chain so the boat works on and off
+// VDatum coverage:
+//   1. lake_datum param (if set)            — wins outright everywhere
+//   2. config entries with override == true — beat VDatum
+//   3. VDatum (PROJ) result                 — where grids cover the point
+//   4. config entries with override == false (default) — fill VDatum gaps
+//   5. nothing matches                      — chart_datum is NOT published
+//      (navigation continues on the ellipsoidal map / map_tide); a loud
+//      warning is logged. This is the #8 "optional/additive" chart_datum.
 //
-// Position is obtained from the TF tree (earth → base_link → ECEF →
-// lat/lon via geodesy).
+// The resolution itself lives in the pure mru_transform::resolve_datum() core
+// (datum_config.hpp) so the precedence is unit-testable. The active source is
+// logged and published on the latched `datum_source` topic so consumers and
+// operators can distinguish a surveyed datum from "none".
 //
-// Requires:
+// The offsets are position-dependent and recalculated periodically. Transforms
+// are published at a faster rate using cached values. Position is obtained from
+// the TF tree (earth → base_link → ECEF → lat/lon via geodesy).
+//
+// VDatum is optional. When used it requires:
 //   - PROJ geoid grid (e.g., us_noaa_g2018u0.tif) for ellipsoid → NAVD88
-//   - VDatum regional .gtx grids for NAVD88 → MLLW
-//   - VDatum regional .gtx grids for NAVD88 → MHHW (optional)
+//   - VDatum regional .gtx grids for NAVD88 → MLLW (and optionally → MHHW)
 
 #include <cmath>
 #include <filesystem>
+#include <limits>
+#include <optional>
 #include <string>
+#include <vector>
 
 #include "proj.h"
 
@@ -25,9 +38,12 @@
 #include "rclcpp_lifecycle/lifecycle_node.hpp"
 #include "lifecycle_msgs/msg/state.hpp"
 #include "std_msgs/msg/float64.hpp"
+#include "std_msgs/msg/string.hpp"
 #include "tf2_ros/buffer.h"
 #include "tf2_ros/transform_broadcaster.h"
 #include "tf2_ros/transform_listener.h"
+
+#include "mru_transform/datum_config.hpp"
 
 namespace fs = std::filesystem;
 
@@ -73,18 +89,56 @@ public:
     declare_parameter("recalc_interval", recalc_interval_);
     get_parameter("recalc_interval", recalc_interval_);
 
-    if (geoid_grid_path_.empty()) {
-      RCLCPP_ERROR(get_logger(), "geoid_grid parameter is required");
-      return CallbackReturn::FAILURE;
-    }
+    declare_parameter("datum_config_path", std::string(""));
+    get_parameter("datum_config_path", datum_config_path_);
 
+    // NaN sentinel means "unset". lake_datum, when set, overrides everything.
+    const double kUnset = std::numeric_limits<double>::quiet_NaN();
+    declare_parameter("lake_datum", kUnset);
+    get_parameter("lake_datum", lake_datum_);
+    declare_parameter("lake_datum_mhhw", kUnset);
+    get_parameter("lake_datum_mhhw", lake_datum_mhhw_);
+
+    // VDatum is optional: enabled only when both grids are configured and the
+    // PROJ pipeline sets up. Failure here is non-fatal — the config/param/absent
+    // paths still let the boat operate anywhere.
+    vdatum_enabled_ = false;
     if (vdatum_grid_dir_.empty()) {
-      RCLCPP_ERROR(get_logger(), "vdatum_grid_dir parameter is required");
-      return CallbackReturn::FAILURE;
+      RCLCPP_INFO(
+        get_logger(),
+        "No vdatum_grid_dir — VDatum disabled; using config/param datums only");
+    } else if (geoid_grid_path_.empty()) {
+      RCLCPP_WARN(
+        get_logger(),
+        "vdatum_grid_dir is set but geoid_grid is empty — VDatum disabled");
+    } else if (setup_proj()) {
+      vdatum_enabled_ = true;
+    } else {
+      RCLCPP_WARN(
+        get_logger(),
+        "VDatum setup failed — continuing without VDatum (config/param/absent)");
     }
 
-    if (!setup_proj()) {
-      return CallbackReturn::FAILURE;
+    // Load the polygon→datum config, if a path was given. A malformed config is
+    // an operator error worth failing loudly on (configure can be retried).
+    if (!datum_config_path_.empty()) {
+      try {
+        datum_entries_ = mru_transform::load_datum_config(datum_config_path_);
+        RCLCPP_INFO(
+          get_logger(), "Loaded %zu datum polygon(s) from %s",
+          datum_entries_.size(), datum_config_path_.c_str());
+      } catch (const std::exception & e) {
+        RCLCPP_ERROR(get_logger(), "Failed to load datum config: %s", e.what());
+        return CallbackReturn::FAILURE;
+      }
+    }
+
+    if (!std::isnan(lake_datum_)) {
+      RCLCPP_INFO(
+        get_logger(),
+        "lake_datum override set: chart_datum %.3f m (rel. ellipsoid) — "
+        "wins over VDatum and config everywhere",
+        lake_datum_);
     }
 
     tf_buffer_ = std::make_shared<tf2_ros::Buffer>(get_clock());
@@ -95,6 +149,8 @@ public:
     auto latched_qos = rclcpp::QoS(1).transient_local();
     mllw_pub_ = create_publisher<std_msgs::msg::Float64>("mllw_offset", latched_qos);
     mhhw_pub_ = create_publisher<std_msgs::msg::Float64>("mhhw_offset", latched_qos);
+    datum_source_pub_ =
+      create_publisher<std_msgs::msg::String>("datum_source", latched_qos);
 
     return LifecycleNode::on_configure(state);
   }
@@ -125,9 +181,15 @@ public:
   CallbackReturn on_cleanup(const rclcpp_lifecycle::State & state)
   {
     cleanup_proj();
+    vdatum_enabled_ = false;
+    datum_entries_.clear();
+    datum_source_ = "none";
+    has_valid_mllw_ = false;
+    has_valid_mhhw_ = false;
     tf_buffer_.reset();
     tf_listener_.reset();
     tf_broadcaster_.reset();
+    datum_source_pub_.reset();
     return LifecycleNode::on_cleanup(state);
   }
 
@@ -255,6 +317,54 @@ private:
     return true;
   }
 
+  // Query the VDatum PROJ pipelines at a point. Returns nullopt when VDatum is
+  // disabled or has no MLLW coverage there.
+  std::optional<mru_transform::VDatumResult> query_vdatum(
+    double latitude, double longitude)
+  {
+    if (!vdatum_enabled_) {
+      return std::nullopt;
+    }
+    const double lon_rad = proj_torad(longitude);
+    const double lat_rad = proj_torad(latitude);
+
+    double mllw_z;
+    if (!query_datum(proj_mllw_, lon_rad, lat_rad, mllw_z)) {
+      RCLCPP_WARN_THROTTLE(
+        get_logger(), *get_clock(), 30000,
+        "No VDatum MLLW coverage at (%.4f, %.4f)", latitude, longitude);
+      return std::nullopt;
+    }
+
+    mru_transform::VDatumResult vr;
+    vr.mllw_z = mllw_z;
+    if (proj_mhhw_) {
+      double mhhw_z;
+      if (query_datum(proj_mhhw_, lon_rad, lat_rad, mhhw_z)) {
+        vr.mhhw_z = mhhw_z;
+      } else {
+        RCLCPP_WARN_THROTTLE(
+          get_logger(), *get_clock(), 30000,
+          "No VDatum MHHW coverage at (%.4f, %.4f)", latitude, longitude);
+      }
+    }
+    return vr;
+  }
+
+  static std::string source_label(
+    mru_transform::DatumSource source, const std::string & name)
+  {
+    switch (source) {
+      case mru_transform::DatumSource::VDATUM:
+        return "vdatum";
+      case mru_transform::DatumSource::POLYGON_CONFIG:
+        return "polygon:" + name;
+      case mru_transform::DatumSource::PARAM:
+        return "param";
+    }
+    return "unknown";
+  }
+
   void recalc_callback()
   {
     // Look up earth → base_link to get ECEF position
@@ -277,45 +387,53 @@ private:
 
     auto geo = geodesy::toMsg(geodesy::ECEFPoint(ecef_point));
 
-    double lon_rad = proj_torad(geo.longitude);
-    double lat_rad = proj_torad(geo.latitude);
+    // Resolve the datum via the pure precedence chain.
+    auto vdatum = query_vdatum(geo.latitude, geo.longitude);
+    std::optional<double> lake = std::isnan(lake_datum_) ?
+      std::nullopt : std::optional<double>(lake_datum_);
+    std::optional<double> lake_mhhw = std::isnan(lake_datum_mhhw_) ?
+      std::nullopt : std::optional<double>(lake_datum_mhhw_);
 
-    // MLLW (required)
-    double mllw_z;
-    if (!query_datum(proj_mllw_, lon_rad, lat_rad, mllw_z)) {
+    auto result = mru_transform::resolve_datum(
+      geo.latitude, geo.longitude, lake, lake_mhhw, vdatum, datum_entries_);
+
+    if (!result.has_value()) {
+      has_valid_mllw_ = false;
+      has_valid_mhhw_ = false;
+      datum_source_ = "none";
       RCLCPP_WARN_THROTTLE(
         get_logger(), *get_clock(), 30000,
-        "No VDatum MLLW coverage at (%.4f, %.4f)",
+        "No datum at (%.4f, %.4f) — VDatum/config/param all unavailable; "
+        "chart_datum will not be published (navigation uses map_tide)",
         geo.latitude, geo.longitude);
       return;
     }
 
-    chart_datum_z_ = mllw_z;
+    chart_datum_z_ = result->chart_datum_z;
     has_valid_mllw_ = true;
+    if (result->mhhw_z.has_value()) {
+      mhhw_z_ = *result->mhhw_z;
+      has_valid_mhhw_ = true;
+    } else {
+      has_valid_mhhw_ = false;
+    }
 
-    RCLCPP_INFO_ONCE(
-      get_logger(),
-      "Chart datum at (%.4f, %.4f): %.3f m (MLLW below ellipsoid)",
-      geo.latitude, geo.longitude, chart_datum_z_);
-
-    // MHHW (optional)
-    if (proj_mhhw_) {
-      double mhhw_z;
-      if (query_datum(proj_mhhw_, lon_rad, lat_rad, mhhw_z)) {
-        mhhw_z_ = mhhw_z;
-        has_valid_mhhw_ = true;
-
-        RCLCPP_INFO_ONCE(
+    const std::string source = source_label(result->source, result->name);
+    if (source != datum_source_) {
+      datum_source_ = source;
+      if (has_valid_mhhw_) {
+        RCLCPP_INFO(
           get_logger(),
-          "MHHW at (%.4f, %.4f): %.3f m (below ellipsoid), "
-          "tidal range: %.3f m",
-          geo.latitude, geo.longitude, mhhw_z_,
-          mhhw_z_ - chart_datum_z_);
+          "Datum at (%.4f, %.4f): chart_datum %.3f m, MHHW %.3f m "
+          "(rel. ellipsoid) [source: %s]",
+          geo.latitude, geo.longitude, chart_datum_z_, mhhw_z_,
+          datum_source_.c_str());
       } else {
-        RCLCPP_WARN_THROTTLE(
-          get_logger(), *get_clock(), 30000,
-          "No VDatum MHHW coverage at (%.4f, %.4f)",
-          geo.latitude, geo.longitude);
+        RCLCPP_INFO(
+          get_logger(),
+          "Datum at (%.4f, %.4f): chart_datum %.3f m (rel. ellipsoid) "
+          "[source: %s]",
+          geo.latitude, geo.longitude, chart_datum_z_, datum_source_.c_str());
       }
     }
   }
@@ -353,6 +471,12 @@ private:
       msg.data = mhhw_z_;
       mhhw_pub_->publish(msg);
     }
+
+    // Provenance: lets consumers/operators distinguish a surveyed datum from
+    // "none" (chart_datum absent) without inspecting the TF tree.
+    std_msgs::msg::String src_msg;
+    src_msg.data = datum_source_;
+    datum_source_pub_->publish(src_msg);
   }
 
   // TF
@@ -363,6 +487,7 @@ private:
   // Debug publishers
   rclcpp_lifecycle::LifecyclePublisher<std_msgs::msg::Float64>::SharedPtr mllw_pub_;
   rclcpp_lifecycle::LifecyclePublisher<std_msgs::msg::Float64>::SharedPtr mhhw_pub_;
+  rclcpp_lifecycle::LifecyclePublisher<std_msgs::msg::String>::SharedPtr datum_source_pub_;
 
   // Timers
   rclcpp::TimerBase::SharedPtr publish_timer_;
@@ -372,6 +497,13 @@ private:
   PJ_CONTEXT * proj_context_ = nullptr;
   PJ * proj_mllw_ = nullptr;
   PJ * proj_mhhw_ = nullptr;
+  bool vdatum_enabled_ = false;
+
+  // Polygon→datum config + fixed-value override.
+  std::vector<mru_transform::DatumEntry> datum_entries_;
+  std::string datum_config_path_;
+  double lake_datum_ = std::numeric_limits<double>::quiet_NaN();
+  double lake_datum_mhhw_ = std::numeric_limits<double>::quiet_NaN();
 
   // Parameters
   std::string chart_datum_frame_ = "chart_datum";
@@ -388,6 +520,7 @@ private:
   double mhhw_z_ = 0.0;
   bool has_valid_mllw_ = false;
   bool has_valid_mhhw_ = false;
+  std::string datum_source_ = "none";
 };
 
 int main(int argc, char * argv[])

--- a/mru_transform/nodes/chart_datum_node.cpp
+++ b/mru_transform/nodes/chart_datum_node.cpp
@@ -89,6 +89,19 @@ public:
     declare_parameter("recalc_interval", recalc_interval_);
     get_parameter("recalc_interval", recalc_interval_);
 
+    // Non-positive timer periods would divide by zero (never publish) or peg a
+    // core (zero-period recalc) — both silent failures.
+    if (publish_rate_ <= 0.0) {
+      RCLCPP_ERROR(
+        get_logger(), "publish_rate must be > 0 (got %.3f)", publish_rate_);
+      return CallbackReturn::FAILURE;
+    }
+    if (recalc_interval_ <= 0.0) {
+      RCLCPP_ERROR(
+        get_logger(), "recalc_interval must be > 0 (got %.3f)", recalc_interval_);
+      return CallbackReturn::FAILURE;
+    }
+
     declare_parameter("datum_config_path", std::string(""));
     get_parameter("datum_config_path", datum_config_path_);
 
@@ -98,6 +111,20 @@ public:
     get_parameter("lake_datum", lake_datum_);
     declare_parameter("lake_datum_mhhw", kUnset);
     get_parameter("lake_datum_mhhw", lake_datum_mhhw_);
+
+    // NaN is the "unset" sentinel; an infinite value is an operator error, not
+    // a datum — normalize it away so it can't reach the TF tree.
+    if (std::isinf(lake_datum_)) {
+      RCLCPP_WARN(
+        get_logger(), "lake_datum is infinite — ignoring (treated as unset)");
+      lake_datum_ = kUnset;
+    }
+    if (std::isinf(lake_datum_mhhw_)) {
+      RCLCPP_WARN(
+        get_logger(),
+        "lake_datum_mhhw is infinite — ignoring (treated as unset)");
+      lake_datum_mhhw_ = kUnset;
+    }
 
     // VDatum is optional: enabled only when both grids are configured and the
     // PROJ pipeline sets up. Failure here is non-fatal — the config/param/absent
@@ -189,7 +216,6 @@ public:
     tf_buffer_.reset();
     tf_listener_.reset();
     tf_broadcaster_.reset();
-    datum_source_pub_.reset();
     return LifecycleNode::on_cleanup(state);
   }
 
@@ -389,10 +415,10 @@ private:
 
     // Resolve the datum via the pure precedence chain.
     auto vdatum = query_vdatum(geo.latitude, geo.longitude);
-    std::optional<double> lake = std::isnan(lake_datum_) ?
-      std::nullopt : std::optional<double>(lake_datum_);
-    std::optional<double> lake_mhhw = std::isnan(lake_datum_mhhw_) ?
-      std::nullopt : std::optional<double>(lake_datum_mhhw_);
+    std::optional<double> lake = std::isfinite(lake_datum_) ?
+      std::optional<double>(lake_datum_) : std::nullopt;
+    std::optional<double> lake_mhhw = std::isfinite(lake_datum_mhhw_) ?
+      std::optional<double>(lake_datum_mhhw_) : std::nullopt;
 
     auto result = mru_transform::resolve_datum(
       geo.latitude, geo.longitude, lake, lake_mhhw, vdatum, datum_entries_);

--- a/mru_transform/package.xml
+++ b/mru_transform/package.xml
@@ -25,6 +25,7 @@
   <depend>std_msgs</depend>
 
   <depend>proj</depend>
+  <depend>yaml-cpp</depend>
 
   <test_depend>ament_cmake_gtest</test_depend>
 

--- a/mru_transform/src/datum_config.cpp
+++ b/mru_transform/src/datum_config.cpp
@@ -1,0 +1,159 @@
+// datum_config.cpp — Implementation of the pure datum resolution core.
+
+#include "mru_transform/datum_config.hpp"
+
+#include <algorithm>
+#include <cmath>
+#include <stdexcept>
+#include <string>
+#include <utility>
+
+#include "yaml-cpp/yaml.h"
+
+namespace mru_transform
+{
+
+namespace
+{
+
+// Is the point collinear with and within the segment a–b? Treats an exact
+// (or near-exact) on-edge point as on the segment.
+bool point_on_segment(double lat, double lon, const LatLon & a, const LatLon & b)
+{
+  constexpr double kEps = 1e-9;
+  // Cross product: zero ⇒ collinear.
+  const double cross =
+    (lon - a.lon) * (b.lat - a.lat) - (lat - a.lat) * (b.lon - a.lon);
+  if (std::abs(cross) > kEps) {
+    return false;
+  }
+  // Within the segment's bounding box (with tolerance).
+  return lon >= std::min(a.lon, b.lon) - kEps &&
+         lon <= std::max(a.lon, b.lon) + kEps &&
+         lat >= std::min(a.lat, b.lat) - kEps &&
+         lat <= std::max(a.lat, b.lat) + kEps;
+}
+
+}  // namespace
+
+bool point_in_ring(double lat, double lon, const std::vector<LatLon> & ring)
+{
+  const size_t n = ring.size();
+  if (n < 3) {
+    return false;
+  }
+
+  // Boundary counts as inside.
+  for (size_t i = 0, j = n - 1; i < n; j = i++) {
+    if (point_on_segment(lat, lon, ring[i], ring[j])) {
+      return true;
+    }
+  }
+
+  // Standard ray-casting (crossing number) test.
+  bool inside = false;
+  for (size_t i = 0, j = n - 1; i < n; j = i++) {
+    const double yi = ring[i].lat, xi = ring[i].lon;
+    const double yj = ring[j].lat, xj = ring[j].lon;
+    const bool crosses = ((yi > lat) != (yj > lat)) &&
+      (lon < (xj - xi) * (lat - yi) / (yj - yi) + xi);
+    if (crosses) {
+      inside = !inside;
+    }
+  }
+  return inside;
+}
+
+std::vector<DatumEntry> load_datum_config(const std::string & path)
+{
+  YAML::Node root;
+  try {
+    root = YAML::LoadFile(path);
+  } catch (const YAML::Exception & e) {
+    throw std::runtime_error(
+      "Failed to load datum config '" + path + "': " + e.what());
+  }
+
+  const YAML::Node polygons = root["datum_polygons"];
+  if (!polygons || !polygons.IsSequence()) {
+    throw std::runtime_error(
+      "Datum config '" + path + "' missing a 'datum_polygons' sequence");
+  }
+
+  std::vector<DatumEntry> entries;
+  for (const auto & node : polygons) {
+    DatumEntry entry;
+    entry.name = node["name"] ? node["name"].as<std::string>()
+                              : std::string("unnamed");
+
+    if (!node["chart_datum_z"]) {
+      throw std::runtime_error(
+        "Datum entry '" + entry.name + "' is missing 'chart_datum_z'");
+    }
+    entry.chart_datum_z = node["chart_datum_z"].as<double>();
+
+    if (node["mhhw_z"]) {
+      entry.mhhw_z = node["mhhw_z"].as<double>();
+    }
+
+    entry.override_vdatum = node["override"] && node["override"].as<bool>();
+
+    const YAML::Node ring = node["ring"];
+    if (!ring || !ring.IsSequence() || ring.size() < 3) {
+      throw std::runtime_error(
+        "Datum entry '" + entry.name +
+        "' needs a 'ring' of at least 3 [lat, lon] points");
+    }
+    for (const auto & pt : ring) {
+      if (!pt.IsSequence() || pt.size() != 2) {
+        throw std::runtime_error(
+          "Datum entry '" + entry.name +
+          "' has a malformed ring vertex (expected [lat, lon])");
+      }
+      entry.ring.push_back(LatLon{pt[0].as<double>(), pt[1].as<double>()});
+    }
+
+    entries.push_back(std::move(entry));
+  }
+  return entries;
+}
+
+std::optional<DatumResult> resolve_datum(
+  double lat, double lon,
+  std::optional<double> lake_datum,
+  std::optional<double> lake_datum_mhhw,
+  const std::optional<VDatumResult> & vdatum,
+  const std::vector<DatumEntry> & entries)
+{
+  // 1. lake_datum param wins outright.
+  if (lake_datum.has_value()) {
+    return DatumResult{DatumSource::PARAM, "param", *lake_datum, lake_datum_mhhw};
+  }
+
+  // 2. config override entries (consulted before VDatum).
+  for (const auto & e : entries) {
+    if (e.override_vdatum && point_in_ring(lat, lon, e.ring)) {
+      return DatumResult{
+        DatumSource::POLYGON_CONFIG, e.name, e.chart_datum_z, e.mhhw_z};
+    }
+  }
+
+  // 3. VDatum.
+  if (vdatum.has_value()) {
+    return DatumResult{
+      DatumSource::VDATUM, "vdatum", vdatum->mllw_z, vdatum->mhhw_z};
+  }
+
+  // 4. config fallback entries (fill VDatum gaps).
+  for (const auto & e : entries) {
+    if (!e.override_vdatum && point_in_ring(lat, lon, e.ring)) {
+      return DatumResult{
+        DatumSource::POLYGON_CONFIG, e.name, e.chart_datum_z, e.mhhw_z};
+    }
+  }
+
+  // 5. Nothing matched.
+  return std::nullopt;
+}
+
+}  // namespace mru_transform

--- a/mru_transform/src/datum_config.cpp
+++ b/mru_transform/src/datum_config.cpp
@@ -81,39 +81,48 @@ std::vector<DatumEntry> load_datum_config(const std::string & path)
   }
 
   std::vector<DatumEntry> entries;
-  for (const auto & node : polygons) {
-    DatumEntry entry;
-    entry.name = node["name"] ? node["name"].as<std::string>()
-                              : std::string("unnamed");
+  // Wrap the per-entry parse so yaml-cpp type-conversion failures (e.g. a
+  // non-numeric chart_datum_z or ring vertex) surface as std::runtime_error,
+  // matching this function's documented contract. Our own validation throws
+  // std::runtime_error directly and passes through untouched.
+  try {
+    for (const auto & node : polygons) {
+      DatumEntry entry;
+      entry.name = node["name"] ? node["name"].as<std::string>()
+                                : std::string("unnamed");
 
-    if (!node["chart_datum_z"]) {
-      throw std::runtime_error(
-        "Datum entry '" + entry.name + "' is missing 'chart_datum_z'");
-    }
-    entry.chart_datum_z = node["chart_datum_z"].as<double>();
+      if (!node["chart_datum_z"]) {
+        throw std::runtime_error(
+          "Datum entry '" + entry.name + "' is missing 'chart_datum_z'");
+      }
+      entry.chart_datum_z = node["chart_datum_z"].as<double>();
 
-    if (node["mhhw_z"]) {
-      entry.mhhw_z = node["mhhw_z"].as<double>();
-    }
+      if (node["mhhw_z"]) {
+        entry.mhhw_z = node["mhhw_z"].as<double>();
+      }
 
-    entry.override_vdatum = node["override"] && node["override"].as<bool>();
+      entry.override_vdatum = node["override"] && node["override"].as<bool>();
 
-    const YAML::Node ring = node["ring"];
-    if (!ring || !ring.IsSequence() || ring.size() < 3) {
-      throw std::runtime_error(
-        "Datum entry '" + entry.name +
-        "' needs a 'ring' of at least 3 [lat, lon] points");
-    }
-    for (const auto & pt : ring) {
-      if (!pt.IsSequence() || pt.size() != 2) {
+      const YAML::Node ring = node["ring"];
+      if (!ring || !ring.IsSequence() || ring.size() < 3) {
         throw std::runtime_error(
           "Datum entry '" + entry.name +
-          "' has a malformed ring vertex (expected [lat, lon])");
+          "' needs a 'ring' of at least 3 [lat, lon] points");
       }
-      entry.ring.push_back(LatLon{pt[0].as<double>(), pt[1].as<double>()});
-    }
+      for (const auto & pt : ring) {
+        if (!pt.IsSequence() || pt.size() != 2) {
+          throw std::runtime_error(
+            "Datum entry '" + entry.name +
+            "' has a malformed ring vertex (expected [lat, lon])");
+        }
+        entry.ring.push_back(LatLon{pt[0].as<double>(), pt[1].as<double>()});
+      }
 
-    entries.push_back(std::move(entry));
+      entries.push_back(std::move(entry));
+    }
+  } catch (const YAML::Exception & e) {
+    throw std::runtime_error(
+      "Malformed datum config '" + path + "': " + e.what());
   }
   return entries;
 }

--- a/mru_transform/test/test_datum_config.cpp
+++ b/mru_transform/test/test_datum_config.cpp
@@ -1,0 +1,249 @@
+// Tests for the pure datum resolution core (mru_transform::datum_config).
+//
+// Covers acceptance item 5 of issue #25 in pure code: the precedence matrix
+// (param-first / override-beats-VDatum / fallback-loses-to-VDatum /
+// fallback-fills-gap / nothing→none, plus MHHW present vs absent), the
+// point-in-polygon predicate (inside / outside / boundary / overlap), and
+// config parsing (valid / missing / malformed / override default).
+
+#include <unistd.h>
+
+#include <cstdio>
+#include <optional>
+#include <string>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+#include "mru_transform/datum_config.hpp"
+
+using mru_transform::DatumEntry;
+using mru_transform::DatumSource;
+using mru_transform::LatLon;
+using mru_transform::VDatumResult;
+using mru_transform::load_datum_config;
+using mru_transform::point_in_ring;
+using mru_transform::resolve_datum;
+
+namespace
+{
+
+// A unit square ring [0,1] x [0,1] in (lat, lon).
+std::vector<LatLon> unitSquare()
+{
+  return {{0.0, 0.0}, {0.0, 1.0}, {1.0, 1.0}, {1.0, 0.0}};
+}
+
+// One config entry covering a small area around (43, -71).
+DatumEntry lakeEntry(bool override_vdatum, double z = -25.0)
+{
+  DatumEntry e;
+  e.name = "lake";
+  e.ring = {{42.0, -72.0}, {42.0, -70.0}, {44.0, -70.0}, {44.0, -72.0}};
+  e.chart_datum_z = z;
+  e.override_vdatum = override_vdatum;
+  return e;
+}
+
+// Write text to a unique temp file; returns the path.
+std::string writeTemp(const std::string & contents)
+{
+  char tmpl[] = "/tmp/datum_cfg_XXXXXX";
+  const int fd = mkstemp(tmpl);
+  EXPECT_GE(fd, 0) << "mkstemp failed";
+  if (fd >= 0) {
+    const ssize_t written = write(fd, contents.data(), contents.size());
+    EXPECT_EQ(static_cast<size_t>(written), contents.size());
+    close(fd);
+  }
+  return std::string(tmpl);
+}
+
+}  // namespace
+
+// ---- point_in_ring -------------------------------------------------------
+
+TEST(PointInRing, InsideAndOutside)
+{
+  const auto ring = unitSquare();
+  EXPECT_TRUE(point_in_ring(0.5, 0.5, ring));
+  EXPECT_FALSE(point_in_ring(2.0, 0.5, ring));
+  EXPECT_FALSE(point_in_ring(0.5, -0.5, ring));
+}
+
+TEST(PointInRing, BoundaryCountsAsInside)
+{
+  const auto ring = unitSquare();
+  EXPECT_TRUE(point_in_ring(0.0, 0.5, ring));   // on an edge
+  EXPECT_TRUE(point_in_ring(0.0, 0.0, ring));   // on a vertex
+  EXPECT_TRUE(point_in_ring(1.0, 1.0, ring));   // on a vertex
+}
+
+TEST(PointInRing, DegenerateRingIsNeverInside)
+{
+  std::vector<LatLon> two = {{0.0, 0.0}, {1.0, 1.0}};
+  EXPECT_FALSE(point_in_ring(0.5, 0.5, two));
+}
+
+// ---- resolve_datum precedence -------------------------------------------
+
+TEST(ResolveDatum, ParamWinsOutright)
+{
+  std::vector<DatumEntry> entries = {lakeEntry(/*override=*/true, -10.0)};
+  VDatumResult vd{-3.0, std::nullopt};
+  // Point is inside the override polygon AND has VDatum, yet param wins.
+  auto r = resolve_datum(43.0, -71.0, /*lake=*/-7.5, /*lake_mhhw=*/-7.0, vd, entries);
+  ASSERT_TRUE(r.has_value());
+  EXPECT_EQ(r->source, DatumSource::PARAM);
+  EXPECT_DOUBLE_EQ(r->chart_datum_z, -7.5);
+  ASSERT_TRUE(r->mhhw_z.has_value());
+  EXPECT_DOUBLE_EQ(*r->mhhw_z, -7.0);
+}
+
+TEST(ResolveDatum, OverrideEntryBeatsVDatum)
+{
+  std::vector<DatumEntry> entries = {lakeEntry(/*override=*/true, -10.0)};
+  VDatumResult vd{-3.0, std::nullopt};
+  auto r = resolve_datum(43.0, -71.0, std::nullopt, std::nullopt, vd, entries);
+  ASSERT_TRUE(r.has_value());
+  EXPECT_EQ(r->source, DatumSource::POLYGON_CONFIG);
+  EXPECT_EQ(r->name, "lake");
+  EXPECT_DOUBLE_EQ(r->chart_datum_z, -10.0);
+}
+
+TEST(ResolveDatum, FallbackEntryLosesToVDatum)
+{
+  std::vector<DatumEntry> entries = {lakeEntry(/*override=*/false, -10.0)};
+  VDatumResult vd{-3.0, -2.5};
+  auto r = resolve_datum(43.0, -71.0, std::nullopt, std::nullopt, vd, entries);
+  ASSERT_TRUE(r.has_value());
+  EXPECT_EQ(r->source, DatumSource::VDATUM);
+  EXPECT_DOUBLE_EQ(r->chart_datum_z, -3.0);
+  ASSERT_TRUE(r->mhhw_z.has_value());
+  EXPECT_DOUBLE_EQ(*r->mhhw_z, -2.5);
+}
+
+TEST(ResolveDatum, FallbackEntryFillsVDatumGap)
+{
+  std::vector<DatumEntry> entries = {lakeEntry(/*override=*/false, -10.0)};
+  // No VDatum coverage here.
+  auto r = resolve_datum(43.0, -71.0, std::nullopt, std::nullopt, std::nullopt, entries);
+  ASSERT_TRUE(r.has_value());
+  EXPECT_EQ(r->source, DatumSource::POLYGON_CONFIG);
+  EXPECT_DOUBLE_EQ(r->chart_datum_z, -10.0);
+  EXPECT_FALSE(r->mhhw_z.has_value());
+}
+
+TEST(ResolveDatum, NothingMatchesYieldsNone)
+{
+  std::vector<DatumEntry> entries = {lakeEntry(/*override=*/false)};
+  // Point outside the polygon, no VDatum, no param.
+  auto r = resolve_datum(10.0, 10.0, std::nullopt, std::nullopt, std::nullopt, entries);
+  EXPECT_FALSE(r.has_value());
+}
+
+TEST(ResolveDatum, EmptyEverythingYieldsNone)
+{
+  auto r = resolve_datum(43.0, -71.0, std::nullopt, std::nullopt, std::nullopt, {});
+  EXPECT_FALSE(r.has_value());
+}
+
+TEST(ResolveDatum, FirstMatchWinsOnOverlap)
+{
+  DatumEntry a = lakeEntry(/*override=*/false, -10.0);
+  a.name = "first";
+  DatumEntry b = lakeEntry(/*override=*/false, -20.0);
+  b.name = "second";
+  std::vector<DatumEntry> entries = {a, b};
+  auto r = resolve_datum(43.0, -71.0, std::nullopt, std::nullopt, std::nullopt, entries);
+  ASSERT_TRUE(r.has_value());
+  EXPECT_EQ(r->name, "first");
+}
+
+// ---- load_datum_config ---------------------------------------------------
+
+TEST(LoadDatumConfig, ValidFileParses)
+{
+  const std::string yaml =
+    "datum_polygons:\n"
+    "  - name: \"Lake A\"\n"
+    "    chart_datum_z: -25.0\n"
+    "    mhhw_z: -24.5\n"
+    "    override: true\n"
+    "    ring:\n"
+    "      - [43.0, -71.4]\n"
+    "      - [43.0, -71.3]\n"
+    "      - [42.9, -71.3]\n"
+    "      - [42.9, -71.4]\n";
+  const std::string path = writeTemp(yaml);
+  auto entries = load_datum_config(path);
+  std::remove(path.c_str());
+
+  ASSERT_EQ(entries.size(), 1u);
+  EXPECT_EQ(entries[0].name, "Lake A");
+  EXPECT_DOUBLE_EQ(entries[0].chart_datum_z, -25.0);
+  ASSERT_TRUE(entries[0].mhhw_z.has_value());
+  EXPECT_DOUBLE_EQ(*entries[0].mhhw_z, -24.5);
+  EXPECT_TRUE(entries[0].override_vdatum);
+  EXPECT_EQ(entries[0].ring.size(), 4u);
+}
+
+TEST(LoadDatumConfig, OverrideAndMhhwDefault)
+{
+  const std::string yaml =
+    "datum_polygons:\n"
+    "  - name: \"Lake B\"\n"
+    "    chart_datum_z: -5.0\n"
+    "    ring:\n"
+    "      - [1.0, 1.0]\n"
+    "      - [1.0, 2.0]\n"
+    "      - [2.0, 2.0]\n";
+  const std::string path = writeTemp(yaml);
+  auto entries = load_datum_config(path);
+  std::remove(path.c_str());
+
+  ASSERT_EQ(entries.size(), 1u);
+  EXPECT_FALSE(entries[0].override_vdatum);   // default false
+  EXPECT_FALSE(entries[0].mhhw_z.has_value());  // optional, omitted
+}
+
+TEST(LoadDatumConfig, MissingFileThrows)
+{
+  EXPECT_THROW(
+    load_datum_config("/nonexistent/path/datum.yaml"), std::runtime_error);
+}
+
+TEST(LoadDatumConfig, MissingChartDatumZThrows)
+{
+  const std::string yaml =
+    "datum_polygons:\n"
+    "  - name: \"No Z\"\n"
+    "    ring:\n"
+    "      - [1.0, 1.0]\n"
+    "      - [1.0, 2.0]\n"
+    "      - [2.0, 2.0]\n";
+  const std::string path = writeTemp(yaml);
+  EXPECT_THROW(load_datum_config(path), std::runtime_error);
+  std::remove(path.c_str());
+}
+
+TEST(LoadDatumConfig, TooFewRingPointsThrows)
+{
+  const std::string yaml =
+    "datum_polygons:\n"
+    "  - name: \"Sliver\"\n"
+    "    chart_datum_z: -5.0\n"
+    "    ring:\n"
+    "      - [1.0, 1.0]\n"
+    "      - [1.0, 2.0]\n";
+  const std::string path = writeTemp(yaml);
+  EXPECT_THROW(load_datum_config(path), std::runtime_error);
+  std::remove(path.c_str());
+}
+
+TEST(LoadDatumConfig, MissingTopLevelKeyThrows)
+{
+  const std::string path = writeTemp("some_other_key: 1\n");
+  EXPECT_THROW(load_datum_config(path), std::runtime_error);
+  std::remove(path.c_str());
+}

--- a/mru_transform/test/test_datum_config.cpp
+++ b/mru_transform/test/test_datum_config.cpp
@@ -85,6 +85,36 @@ TEST(PointInRing, DegenerateRingIsNeverInside)
   EXPECT_FALSE(point_in_ring(0.5, 0.5, two));
 }
 
+TEST(PointInRing, CollinearButOutsideSegmentIsNotInside)
+{
+  // Point on the line of the bottom edge (lat=0) but beyond the segment's
+  // longitude range — must be rejected by the on-segment bounding-box check
+  // and not counted as on-boundary.
+  const auto ring = unitSquare();
+  EXPECT_FALSE(point_in_ring(0.0, 2.0, ring));
+  EXPECT_FALSE(point_in_ring(0.0, -1.0, ring));
+}
+
+TEST(PointInRing, VertexLatitudeDoesNotDoubleCount)
+{
+  // A horizontal ray at the latitude of the top vertices (lat=1.0) must not be
+  // mis-counted by the half-open ray-cast convention. A point well to the left
+  // at that latitude is outside; the top edge itself is boundary (inside).
+  const auto ring = unitSquare();
+  EXPECT_FALSE(point_in_ring(1.0, -1.0, ring));   // left of the ring, on top edge's lat
+  EXPECT_TRUE(point_in_ring(1.0, 0.5, ring));     // on the top edge → inside
+}
+
+TEST(PointInRing, ConcaveRingExcludesTheNotch)
+{
+  // An L-shaped (concave) ring: the notch must read as outside even though it
+  // is within the bounding box.
+  std::vector<LatLon> ell = {
+    {0.0, 0.0}, {0.0, 2.0}, {1.0, 2.0}, {1.0, 1.0}, {2.0, 1.0}, {2.0, 0.0}};
+  EXPECT_TRUE(point_in_ring(0.5, 0.5, ell));    // in the solid corner
+  EXPECT_FALSE(point_in_ring(1.5, 1.5, ell));   // in the removed notch
+}
+
 // ---- resolve_datum precedence -------------------------------------------
 
 TEST(ResolveDatum, ParamWinsOutright)
@@ -244,6 +274,39 @@ TEST(LoadDatumConfig, TooFewRingPointsThrows)
 TEST(LoadDatumConfig, MissingTopLevelKeyThrows)
 {
   const std::string path = writeTemp("some_other_key: 1\n");
+  EXPECT_THROW(load_datum_config(path), std::runtime_error);
+  std::remove(path.c_str());
+}
+
+TEST(LoadDatumConfig, MalformedRingVertexThrowsRuntimeError)
+{
+  // A ring vertex that is not a 2-element [lat, lon] sequence.
+  const std::string yaml =
+    "datum_polygons:\n"
+    "  - name: \"Bad Vertex\"\n"
+    "    chart_datum_z: -5.0\n"
+    "    ring:\n"
+    "      - [1.0, 1.0]\n"
+    "      - [1.0]\n"
+    "      - [2.0, 2.0]\n";
+  const std::string path = writeTemp(yaml);
+  EXPECT_THROW(load_datum_config(path), std::runtime_error);
+  std::remove(path.c_str());
+}
+
+TEST(LoadDatumConfig, NonNumericChartDatumZThrowsRuntimeError)
+{
+  // A yaml-cpp type-conversion failure must surface as std::runtime_error,
+  // per the function's documented contract (not a raw YAML::Exception).
+  const std::string yaml =
+    "datum_polygons:\n"
+    "  - name: \"Bad Z\"\n"
+    "    chart_datum_z: \"not-a-number\"\n"
+    "    ring:\n"
+    "      - [1.0, 1.0]\n"
+    "      - [1.0, 2.0]\n"
+    "      - [2.0, 2.0]\n";
+  const std::string path = writeTemp(yaml);
   EXPECT_THROW(load_datum_config(path), std::runtime_error);
   std::remove(path.c_str());
 }


### PR DESCRIPTION
Closes #25

# Plan: Datum support off-VDatum: polygon-keyed datum config (always-on) + lake_datum override

## Issue

https://github.com/rolker/mru_transform/issues/25

## Context

`chart_datum_node` (a `LifecycleNode`) publishes `map → chart_datum`/`mhhw` TF
from NOAA VDatum `.gtx` grids via PROJ. Two gaps block "works anywhere":

1. `on_configure` **hard-fails** (`CallbackReturn::FAILURE`) when `vdatum_grid_dir`
   is empty — so the node won't even configure with no grids.
2. `recalc_callback` only sets `has_valid_mllw_` on a VDatum hit; `publish_callback`
   gates publishing on that flag. Off-VDatum (e.g. Massabesic, inside the grid dir
   but outside coverage) **no `chart_datum` frame is published at all**.

We add a datum **resolution chain** that populates `chart_datum` from whichever real
datum is available, tracking and logging the source. When **nothing** matches we
leave `chart_datum` **absent** and navigation continues on `map_tide`.

### Resolution order (resolved 2026-06-13/14)

1. **`lake_datum` param** — if set (NaN sentinel = unset), wins outright everywhere.
   Deliberate operator action for one-offs/testing; least-surprising if it overrides
   VDatum too. Source = `PARAM`.
2. **config override-entries** — polygon entries flagged `override: true` whose ring
   contains the point. Source = `POLYGON_CONFIG`.
3. **VDatum** — PROJ pipeline result where grids cover the point. Source = `VDATUM`.
4. **config fallback-entries** — polygon entries with `override: false` (the default)
   whose ring contains the point. Source = `POLYGON_CONFIG`.
5. **NONE** — `chart_datum` absent + loud WARN.

Within a pass, the **first** matching entry in file order wins (documented).

### Resolved design decisions (issue #25 discussion)

- **Q1 — config format: yaml-cpp file** (`datum_config_path` param); natural for
  variable-length polygon rings. One new, well-established ROS 2 dependency.
- **Q2 — "nothing matches": `chart_datum` absent + loud WARN** (NOT z=0). This is
  #8's "optional/additive" design for `chart_datum`. Honors acceptance item 4's
  *intent* ("never hard-fail") while reinterpreting its *mechanism*: the safe default
  is "no chart_datum, nav on the ellipsoidal `map`/`map_tide`," not a z=0 frame that
  would assert a false `chart_datum == ellipsoid` equality.
- **Q3 — no consumer change in scope.** Verified in code: `sea_surface_estimator`
  (this repo) and `s57_layer` (`s57_tools`) both try/catch the lookup and degrade
  safely. Absence off-VDatum is the pre-existing status quo; this PR only *adds* real
  datums, never a wrong one.
- **Q4 — config positioning: per-entry `override` flag (default false), two-pass
  around VDatum** — NOT a single global flag. Lets one polygon override VDatum (a
  trusted local survey) while another only fills gaps, without flipping the whole
  file into override mode. Safe default (forgotten flag = fallback).

## Approach

1. **Pure, ROS-free resolution core** — `include/mru_transform/datum_config.hpp`
   (+ `src/datum_config.cpp`). Types:
   - `DatumEntry { std::string name; std::vector<std::pair<double,double>> ring;
     double chart_datum_z; std::optional<double> mhhw_z; bool override_vdatum = false; }`
   - `VDatumResult { double mllw_z; std::optional<double> mhhw_z; }`
   - `DatumResult { DatumSource source; std::string name; double chart_datum_z;
     std::optional<double> mhhw_z; }`, `enum class DatumSource {VDATUM, POLYGON_CONFIG, PARAM}`
   Functions: `point_in_ring()` (ray-cast), `load_datum_config(path)` (yaml-cpp parse),
   and the **whole precedence chain** as one pure function:
   `std::optional<DatumResult> resolve_datum(lat, lon, lake_param, lake_mhhw_param,
   std::optional<VDatumResult> vdatum, const std::vector<DatumEntry>& entries)`
   returning `nullopt` for NONE. Encapsulating the chain here (not in the node) is
   what makes the precedence matrix unit-testable — addresses plan-review finding 1.
2. **Make VDatum optional in `on_configure`** — if `vdatum_grid_dir` is empty or no
   MLLW grids found, skip PROJ setup and log once (INFO), do **not** FAILURE. Keep
   `geoid_grid` required only when VDatum is used. PROJ pointers stay null → guarded.
3. **Add parameters** — `datum_config_path` (string, ""), `lake_datum` (double, NaN =
   unset; fixed datum-below-ellipsoid z), `lake_datum_mhhw` (double, NaN = unset).
   (No global override flag — per-entry now.) Declare/get in `on_configure`; load the
   config file there if the path is set (yaml-cpp); each entry parses its optional
   `override` field (default false).
4. **`recalc_callback` becomes thin** — query PROJ for an `optional<VDatumResult>`
   (nullopt when no coverage / VDatum disabled), read the params, call
   `resolve_datum(...)`. On a result: set `chart_datum_z_`, optional `mhhw_z_`, source,
   name; `has_valid_mllw_ = true`; `has_valid_mhhw_` only if the result carries MHHW.
   On `nullopt`: `has_valid_mllw_ = false` so `publish_callback` leaves `chart_datum`
   absent, plus a throttled `RCLCPP_WARN`. Log the source+name with `RCLCPP_INFO` on
   change (source can change as the boat moves).
5. **Publish provenance** — latched `std_msgs::msg::String` publisher `datum_source`
   (`"vdatum"`, `"polygon:<name>"`, `"param"`, `"none"`) so consumers/operators can
   distinguish "no datum here" from a surveyed one. Publish in `publish_callback`
   (including `"none"` when absent).
6. **Ship a generic example config, not Massabesic data** —
   `config/datum_polygons.example.yaml` with a documented schema (including the
   `override` field) and one *synthetic* entry. Real Lake Massabesic polygon goes in
   the platform/site overlay (echoboats/bizzy) as a follow-up, via `datum_config_path`.
   Satisfies acceptance item 6 in the right repo.
7. **Tests** — `test/test_datum_config.cpp` (gtest):
   - `point_in_ring`: inside, outside, on-boundary, overlapping-rings first-match,
     antimeridian limitation (documented, not handled).
   - `load_datum_config`: valid, missing-file, malformed, `override` default false.
   - `resolve_datum` precedence matrix: param-first-wins; override-entry beats VDatum;
     fallback-entry loses to VDatum; fallback-entry fills a VDatum gap; NONE when
     nothing matches; MHHW present vs absent. This covers acceptance item 5's matrix
     in pure code (the PROJ query itself is the only untested seam).
   Register in `CMakeLists.txt`.
8. **Docs** — `chart_datum_node.cpp` header, `launch/chart_datum_launch.py` (new
   params), `README.md`: config schema + `override` semantics, resolution order,
   `lake_datum`, absent-when-nothing-matches, and the note that a `chart_datum`-only
   datum (no MHHW) leaves `sea_surface_estimator`'s tide-plausibility bound disabled.

## Files to Change

| File | Change |
|------|--------|
| `include/mru_transform/datum_config.hpp` | New — `DatumEntry`/`VDatumResult`/`DatumResult`/`DatumSource` + `point_in_ring`/`load_datum_config`/`resolve_datum` decls |
| `src/datum_config.cpp` | New — implementations (yaml-cpp parse, ray-cast, full precedence chain) |
| `nodes/chart_datum_node.cpp` | VDatum optional; new params; thin `recalc` delegating to `resolve_datum`; `datum_source` publisher; absent on NONE |
| `config/datum_polygons.example.yaml` | New — documented schema (incl. `override`) + synthetic entry |
| `launch/chart_datum_launch.py` | Surface new params |
| `test/test_datum_config.cpp` | New — gtest for ring/parse/resolve precedence matrix |
| `mru_transform/CMakeLists.txt` | Build `datum_config` lib, link yaml-cpp, register test, `install(DIRECTORY config ...)` |
| `mru_transform/package.xml` | Add `yaml-cpp` (or `yaml_cpp_vendor`) depend |
| `mru_transform/README.md` | Document config/params/resolution order/absent-default |

## Principles Self-Check

| Principle | Consideration |
|---|---|
| A change includes its consequences | Both consumers verified (try/catch tolerance); MHHW-absent interaction documented; absent-default is pre-existing so no consumer change forced. |
| Human control & transparency | `datum_source` topic + per-change logging make provenance visible (incl. `"none"`); per-entry `override` is explicit and defaults safe. |
| Test what breaks | Full precedence chain is pure → the whole matrix (param/override/fallback/VDatum/none/MHHW) is unit-tested. |
| Workspace vs. project separation | Generic mechanism + synthetic example here; Massabesic polygon deferred to the platform overlay. |
| Only what's needed | Single polygon representation; per-entry `override` is ~1 bool + a two-pass loop over the global-flag alternative, and it removes a footgun rather than adding speculative surface. yaml-cpp is the one new dep. |

## ADR Compliance

| ADR | Triggered | How addressed |
|---|---|---|
| 0008 — ROS 2 conventions | Yes | Params declared with defaults; lifecycle pattern preserved; YAML config conventional; target Rolling-compatible APIs. |
| 0001 — ADRs | No (repo has no ADR log) | Capture absent-default + resolution-order rationale in node header + README + PR body. |

## Consequences

| If we change... | Also update... | Status |
|---|---|---|
| Always-resolve datum chain | `sea_surface_estimator` tide-plausibility bound (same repo) | Verified — try/catch tolerates absence; no change |
| Datum absent off-VDatum | `s57_layer` depth→clearance (`s57_tools`, cross-repo) | Verified — try/catch keeps `tide_offset_=0`; no change |
| chart_datum-only entry (no MHHW) | tide-plausibility bound silently disabled (mhhw lookup throws → no-filter) | Documented in step 8; acceptable degradation |
| `chart_datum` semantics | Frame model in #8 (vertical-datum hierarchy) | Aligned — #8 defines `chart_datum` as optional/additive |
| New params + config schema | `chart_datum_launch.py`, README | In plan (steps 3, 8) |
| Real Massabesic polygon | Platform/site overlay (echoboats) | Follow-up issue in platform repo |

## Open Questions

- All resolved — Q1 yaml-cpp; Q2 absent-default; Q3 no consumer change; Q4 per-entry
  `override` (default false) + `lake_datum` param first. Acceptance item 4's mechanism
  was reinterpreted with the issue author's sign-off; worth a one-line note on the
  issue so the record reflects it.

## Estimated Scope

Single PR for the mechanism + tests + example config in `mru_transform`. The real
Massabesic polygon is a separate follow-up in the platform repo; no `s57_layer`
change is needed.
